### PR TITLE
Add SetEnv() to Cmd mocking interface

### DIFF
--- a/exec/exec.go
+++ b/exec/exec.go
@@ -14,6 +14,7 @@ type Cmd interface {
 	Kill() error
 	Output() ([]byte, error)
 	Run() error
+	SetEnv([]string)
 }
 
 // Command is a hook for mocking
@@ -27,4 +28,8 @@ type realCmd struct {
 
 func (c *realCmd) Kill() error {
 	return c.Cmd.Process.Kill()
+}
+
+func (c *realCmd) SetEnv(env []string) {
+	c.Cmd.Env = env
 }

--- a/test/exec/exec.go
+++ b/test/exec/exec.go
@@ -68,6 +68,8 @@ func (c *mockCmd) Run() error {
 	return nil
 }
 
+func (c *mockCmd) SetEnv([]string) {}
+
 func (b *blockingReader) Read(p []byte) (n int, err error) {
 	<-b.quit
 	return 0, nil


### PR DESCRIPTION
Needed for https://github.com/weaveworks/scope/pull/2277