### PR TITLE
invert logic in getRouteName

### DIFF
--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -67,7 +67,7 @@ func (i Instrument) getRouteName(r *http.Request) string {
 		if name := routeMatch.Route.GetName(); name != "" {
 			return name
 		}
-		if tmpl, err := routeMatch.Route.GetPathTemplate(); err != nil {
+		if tmpl, err := routeMatch.Route.GetPathTemplate(); err == nil {
 			return MakeLabelValue(tmpl)
 		}
 	}


### PR DESCRIPTION
When using the `tmpl` variable to create a route match, the error should be `nil` i.e. no error.
Fixes #25