### PR TITLE
Update HTTPRequest extract functions to make it clear which ID they are extracting

### DIFF
--- a/user/http.go
+++ b/user/http.go
@@ -3,29 +3,45 @@ package user
 import (
 	"net/http"
 
+	"github.com/weaveworks/common/errors"
+
 	"golang.org/x/net/context"
 )
 
-// ExtractFromHTTPRequest extracts the user ID from the request headers and returns
-// the user ID and a context with the user ID embbedded.
+const (
+	// orgIDHeaderName is a legacy from scope as a service.
+	orgIDHeaderName = "X-Scope-OrgID"
+
+	// LowerOrgIDHeaderName as gRPC / HTTP2.0 headers are lowercased.
+	lowerOrgIDHeaderName = "x-scope-orgid"
+)
+
+// Errors that we return
+const (
+	ErrNoOrgID               = errors.Error("no org id")
+	ErrDifferentOrgIDPresent = errors.Error("different org ID already present")
+)
+
+// ExtractFromHTTPRequest extracts the org ID from the request headers and returns
+// the org ID and a context with the org ID embbedded.
 func ExtractFromHTTPRequest(r *http.Request) (string, context.Context, error) {
-	userID := r.Header.Get(orgIDHeaderName)
-	if userID == "" {
-		return "", r.Context(), ErrNoUserID
+	orgID := r.Header.Get(orgIDHeaderName)
+	if orgID == "" {
+		return "", r.Context(), ErrNoOrgID
 	}
-	return userID, Inject(r.Context(), userID), nil
+	return orgID, Inject(r.Context(), orgID), nil
 }
 
-// InjectIntoHTTPRequest injects the userID from the context into the request headers.
+// InjectIntoHTTPRequest injects the orgID from the context into the request headers.
 func InjectIntoHTTPRequest(ctx context.Context, r *http.Request) error {
-	userID, err := Extract(ctx)
+	orgID, err := Extract(ctx)
 	if err != nil {
 		return err
 	}
 	existingID := r.Header.Get(orgIDHeaderName)
-	if existingID != "" && existingID != userID {
-		return ErrDifferentIDPresent
+	if existingID != "" && existingID != orgID {
+		return ErrDifferentOrgIDPresent
 	}
-	r.Header.Set(orgIDHeaderName, userID)
+	r.Header.Set(orgIDHeaderName, orgID)
 	return nil
 }

--- a/user/id.go
+++ b/user/id.go
@@ -11,12 +11,6 @@ type contextKey int
 const (
 	// UserIDContextKey is the key used in contexts to find the userid
 	userIDContextKey contextKey = 0
-
-	// orgIDHeaderName is a legacy from scope as a service.
-	orgIDHeaderName = "X-Scope-OrgID"
-
-	// LowerOrgIDHeaderName as gRPC / HTTP2.0 headers are lowercased.
-	lowerOrgIDHeaderName = "x-scope-orgid"
 )
 
 // Errors that we return


### PR DESCRIPTION
There are plans to rename "orgID" in weave cloud to "instanceID" and "userID" in cortex to "principalID".

This change makes it clearer which ID these functions are extracting in the meantime.