### PR TITLE
Use orgID and userID for the user context

### DIFF
--- a/middleware/http_auth.go
+++ b/middleware/http_auth.go
@@ -9,7 +9,7 @@ import (
 // AuthenticateUser propagates the user ID from HTTP headers back to the request's context.
 var AuthenticateUser = Func(func(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, ctx, err := user.ExtractFromHTTPRequest(r)
+		_, ctx, err := user.ExtractOrgIDFromHTTPRequest(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return

--- a/user/grpc.go
+++ b/user/grpc.go
@@ -10,20 +10,20 @@ import (
 func ExtractFromGRPCRequest(ctx context.Context) (string, context.Context, error) {
 	md, ok := metadata.FromContext(ctx)
 	if !ok {
-		return "", ctx, ErrNoUserID
+		return "", ctx, ErrNoOrgID
 	}
 
-	userIDs, ok := md[lowerOrgIDHeaderName]
-	if !ok || len(userIDs) != 1 {
-		return "", ctx, ErrNoUserID
+	orgIDs, ok := md[lowerOrgIDHeaderName]
+	if !ok || len(orgIDs) != 1 {
+		return "", ctx, ErrNoOrgID
 	}
 
-	return userIDs[0], Inject(ctx, userIDs[0]), nil
+	return orgIDs[0], InjectOrgID(ctx, orgIDs[0]), nil
 }
 
-// InjectIntoGRPCRequest injects the userID from the context into the request metadata.
+// InjectIntoGRPCRequest injects the orgID from the context into the request metadata.
 func InjectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
-	userID, err := Extract(ctx)
+	orgID, err := ExtractOrgID(ctx)
 	if err != nil {
 		return ctx, err
 	}
@@ -33,17 +33,17 @@ func InjectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
 		md = metadata.New(map[string]string{})
 	}
 	newCtx := ctx
-	if userIDs, ok := md[lowerOrgIDHeaderName]; ok {
-		if len(userIDs) == 1 {
-			if userIDs[0] != userID {
-				return ctx, ErrDifferentIDPresent
+	if orgIDs, ok := md[lowerOrgIDHeaderName]; ok {
+		if len(orgIDs) == 1 {
+			if orgIDs[0] != orgID {
+				return ctx, ErrDifferentOrgIDPresent
 			}
 		} else {
-			return ctx, ErrTooManyUserIDs
+			return ctx, ErrTooManyOrgIDs
 		}
 	} else {
 		md = md.Copy()
-		md[lowerOrgIDHeaderName] = []string{userID}
+		md[lowerOrgIDHeaderName] = []string{orgID}
 		newCtx = metadata.NewContext(ctx, md)
 	}
 

--- a/user/http.go
+++ b/user/http.go
@@ -16,7 +16,7 @@ const (
 )
 
 // ExtractOrgIDFromHTTPRequest extracts the org ID from the request headers and returns
-// the org ID and a context with the org ID embbedded.
+// the org ID and a context with the org ID embedded.
 func ExtractOrgIDFromHTTPRequest(r *http.Request) (string, context.Context, error) {
 	orgID := r.Header.Get(orgIDHeaderName)
 	if orgID == "" {
@@ -40,7 +40,7 @@ func InjectOrgIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
 }
 
 // ExtractUserIDFromHTTPRequest extracts the org ID from the request headers and returns
-// the org ID and a context with the org ID embbedded.
+// the org ID and a context with the org ID embedded.
 func ExtractUserIDFromHTTPRequest(r *http.Request) (string, context.Context, error) {
 	userID := r.Header.Get(userIDHeaderName)
 	if userID == "" {

--- a/user/http.go
+++ b/user/http.go
@@ -27,7 +27,7 @@ func ExtractOrgIDFromHTTPRequest(r *http.Request) (string, context.Context, erro
 
 // InjectOrgIDIntoHTTPRequest injects the orgID from the context into the request headers.
 func InjectOrgIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
-	orgID, err := Extract(ctx)
+	orgID, err := ExtractOrgID(ctx)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func ExtractUserIDFromHTTPRequest(r *http.Request) (string, context.Context, err
 
 // InjectUserIDIntoHTTPRequest injects the userID from the context into the request headers.
 func InjectUserIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
-	userID, err := Extract(ctx)
+	userID, err := ExtractUserID(ctx)
 	if err != nil {
 		return err
 	}
@@ -61,14 +61,4 @@ func InjectUserIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
 	}
 	r.Header.Set(userIDHeaderName, userID)
 	return nil
-}
-
-// ExtractFromHTTPRequest is deprecated. Use ExtractOrgIDFromHTTPRequest.
-func ExtractFromHTTPRequest(r *http.Request) (string, context.Context, error) {
-	return ExtractOrgIDFromHTTPRequest(r)
-}
-
-// InjectIntoHTTPRequest is deprecated. Use InjectOrgIDIntoHTTPRequest.
-func InjectIntoHTTPRequest(ctx context.Context, r *http.Request) error {
-	return InjectOrgIDIntoHTTPRequest(ctx, r)
 }

--- a/user/id.go
+++ b/user/id.go
@@ -52,13 +52,3 @@ func ExtractUserID(ctx context.Context) (string, error) {
 func InjectUserID(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, interface{}(userIDContextKey), userID)
 }
-
-// Extract is deprecated. Use ExtractOrgID.
-func Extract(ctx context.Context) (string, error) {
-	return ExtractOrgID(ctx)
-}
-
-// Inject is deprecated. Use returns a derived context containing the org ID.
-func Inject(ctx context.Context, orgID string) context.Context {
-	return InjectOrgID(ctx, orgID)
-}

--- a/user/id.go
+++ b/user/id.go
@@ -9,19 +9,38 @@ import (
 type contextKey int
 
 const (
-	// UserIDContextKey is the key used in contexts to find the userid
-	userIDContextKey contextKey = 0
+	// Keys used in contexts to find the org or user ID
+	orgIDContextKey  contextKey = 0
+	userIDContextKey contextKey = 1
 )
 
 // Errors that we return
 const (
-	ErrNoUserID           = errors.Error("no user id")
-	ErrDifferentIDPresent = errors.Error("different user ID already present")
-	ErrTooManyUserIDs     = errors.Error("multiple user IDs present")
+	ErrNoOrgID               = errors.Error("no org id")
+	ErrDifferentOrgIDPresent = errors.Error("different org ID already present")
+	ErrTooManyOrgIDs         = errors.Error("multiple org IDs present")
+
+	ErrNoUserID               = errors.Error("no user id")
+	ErrDifferentUserIDPresent = errors.Error("different user ID already present")
+	ErrTooManyUserIDs         = errors.Error("multiple user IDs present")
 )
 
-// Extract gets the user ID from the context
-func Extract(ctx context.Context) (string, error) {
+// ExtractOrgID gets the org ID from the context.
+func ExtractOrgID(ctx context.Context) (string, error) {
+	orgID, ok := ctx.Value(orgIDContextKey).(string)
+	if !ok {
+		return "", ErrNoOrgID
+	}
+	return orgID, nil
+}
+
+// InjectOrgID returns a derived context containing the org ID.
+func InjectOrgID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, interface{}(orgIDContextKey), userID)
+}
+
+// ExtractUserID gets the user ID from the context.
+func ExtractUserID(ctx context.Context) (string, error) {
 	userID, ok := ctx.Value(userIDContextKey).(string)
 	if !ok {
 		return "", ErrNoUserID
@@ -29,7 +48,17 @@ func Extract(ctx context.Context) (string, error) {
 	return userID, nil
 }
 
-// Inject returns a derived context containing the user ID.
-func Inject(ctx context.Context, userID string) context.Context {
+// InjectUserID returns a derived context containing the user ID.
+func InjectUserID(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, interface{}(userIDContextKey), userID)
+}
+
+// Extract is deprecated. Use ExtractOrgID.
+func Extract(ctx context.Context) (string, error) {
+	return ExtractOrgID(ctx)
+}
+
+// Inject is deprecated. Use returns a derived context containing the org ID.
+func Inject(ctx context.Context, orgID string) context.Context {
+	return InjectOrgID(ctx, orgID)
 }


### PR DESCRIPTION
We have been using the term `userID` to refer to instances (which we call `orgID` elsewhere in our codebase, e.g. headers). We wish to use both `orgID` and `userID` (the individual) in a new service.

This change renames `userID` to `orgID` and creates a new context key for actual `userID`'s (the individuals).

I have proxied the old functions to the `orgID` ones to not break dependant code.
