### PR TITLE
Log request headers, response headers and some body as warning on 500s

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -47,7 +47,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			logWithRequest(r).Warnf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))
 			response, err := i.dumpResponse()
 			if err != nil {
-				logWithRequest(r).Errorf("Could not dump response headers: %v", err)
+				logWithRequest(r).Errorf("Could not dump response: %v", err)
 			} else {
 				logWithRequest(r).Warnf("Response: %s", response)
 			}

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -45,12 +45,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		} else {
 			logWithRequest(r).Warnf("%s %s (%d) %s", r.Method, uri, i.statusCode, time.Since(begin))
 			logWithRequest(r).Warnf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))
-			response, err := i.dumpResponse()
-			if err != nil {
-				logWithRequest(r).Errorf("Could not dump response: %v", err)
-			} else {
-				logWithRequest(r).Warnf("Response: %s", response)
-			}
+			logWithRequest(r).Warnf("Response: %s", i.dumpResponse())
 		}
 	})
 }

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -1,0 +1,157 @@
+package middleware
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+)
+
+const (
+	maxResponseBodyInLogs = 4096 // At most 4k bytes from response bodies in our logs.
+)
+
+// MultiResponseWriter writes a single response to multiple http.ResponseWriters,
+// similar to Unix's `tee` command.
+type MultiResponseWriter struct {
+	rws     []http.ResponseWriter
+	header  http.Header
+	written bool
+}
+
+// NewMultiResponseWriter makes a new response writer.
+func NewMultiResponseWriter(rws ...http.ResponseWriter) *MultiResponseWriter {
+	return &MultiResponseWriter{
+		rws:     rws,
+		header:  http.Header{},
+		written: false,
+	}
+}
+
+// Header returns the header map that will be sent by WriteHeader.
+// Implements ResponseWriter.
+//
+// Note that updates to the headers will not be reflected in child
+// ResponseWriters until 'Write' or 'WriteHeaders' are called.
+func (m *MultiResponseWriter) Header() http.Header {
+	return m.header
+}
+
+func (m *MultiResponseWriter) mirrorHeaders() {
+	for _, rw := range m.rws {
+		theirs := rw.Header()
+		for key := range theirs {
+			theirs.Del(key)
+		}
+		for key, value := range m.header {
+			theirs[key] = value
+		}
+	}
+}
+
+func (m *MultiResponseWriter) Write(data []byte) (int, error) {
+	// The contract of 'Write' has it set headers and call WriteHeader under
+	// certain circmustances. We ignore that here, as we assume that all the
+	// underlying implementations do that for us.
+	m.mirrorHeaders()
+	for _, rw := range m.rws {
+		n, err := rw.Write(data)
+		if err != nil {
+			return n, err
+		}
+		if n < len(data) {
+			return n, io.ErrShortWrite
+		}
+	}
+	return len(data), nil
+}
+
+// WriteHeader writes the HTTP response header.
+func (m *MultiResponseWriter) WriteHeader(statusCode int) {
+	m.mirrorHeaders()
+	for _, rw := range m.rws {
+		rw.WriteHeader(statusCode)
+	}
+}
+
+// Hijack hijacks the first response writer that is a Hijacker.
+func (m *MultiResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	for _, rw := range m.rws {
+		hj, ok := rw.(http.Hijacker)
+		if ok {
+			return hj.Hijack()
+		}
+	}
+	return nil, nil, fmt.Errorf("MultiResponseWriter: can't cast any responses to Hijacker")
+}
+
+// badResponseLogger is an http.ResponseWriter that logs response headers and
+// some of the body when the response is erroneous (i.e. a 5xx).
+//
+// Using this means holding an extra copy of the request and response headers
+// in memory.
+type badResponseLogger struct {
+	recorder      *httptest.ResponseRecorder
+	statusCode    int
+	logBody       bool
+	bodyBytesLeft int
+}
+
+// newBadResponseLogger makes a new badResponseLogger.
+func newBadResponseLogger() *badResponseLogger {
+	return &badResponseLogger{
+		recorder:      httptest.NewRecorder(),
+		logBody:       false,
+		bodyBytesLeft: maxResponseBodyInLogs,
+		statusCode:    http.StatusOK,
+	}
+}
+
+func (b *badResponseLogger) dumpResponse() ([]byte, error) {
+	return httputil.DumpResponse(b.recorder.Result(), true)
+}
+
+// Header implements http.ResponseWriter.
+func (b *badResponseLogger) Header() http.Header {
+	return b.recorder.Header()
+}
+
+// WriteHeader implements http.ResponseWriter. It will immediately log the
+// response headers if `statusCode` is a 5XX.
+func (b *badResponseLogger) WriteHeader(statusCode int) {
+	b.statusCode = statusCode
+	b.recorder.WriteHeader(statusCode)
+	if 100 <= statusCode && statusCode < 500 {
+		return
+	}
+	b.logBody = true
+}
+
+// Write implements http.ResponseWriter. It will log the body up to
+// `maxResponseBodyInLogs` if the response is a 5XX.
+func (b *badResponseLogger) Write(data []byte) (int, error) {
+	// If we haven't written the headers yet, then Write is supposed to call
+	// WriteHeader with http.StatusOK. Since we don't want to do anything in
+	// that case (this struct is for *bad* responses only), we don't need to
+	// track whether or not we've called WriteHeader.
+	if !b.logBody {
+		// We don't need to log anything, so lie and say that we wrote
+		// everything, making this effectively a no-op.
+		return len(data), nil
+	}
+
+	if len(data) > b.bodyBytesLeft {
+		b.recorder.Write(data[:b.bodyBytesLeft])
+		b.recorder.WriteString("…")
+		b.bodyBytesLeft = 0
+	} else {
+		b.recorder.Write(data)
+		b.bodyBytesLeft -= len(data)
+	}
+	// As far as any caller is concerned, we've written the whole response.
+	// There has been no error, nor a short write. Everything is fine.
+	return len(data), nil
+}

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"net"

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 )
@@ -13,130 +12,63 @@ const (
 	maxResponseBodyInLogs = 4096 // At most 4k bytes from response bodies in our logs.
 )
 
-// MultiResponseWriter writes a single response to multiple http.ResponseWriters,
-// similar to Unix's `tee` command.
-type MultiResponseWriter struct {
-	rws     []http.ResponseWriter
-	header  http.Header
-	written bool
-}
-
-// NewMultiResponseWriter makes a new response writer.
-func NewMultiResponseWriter(rws ...http.ResponseWriter) *MultiResponseWriter {
-	return &MultiResponseWriter{
-		rws:     rws,
-		header:  http.Header{},
-		written: false,
-	}
-}
-
-// Header returns the header map that will be sent by WriteHeader.
-// Implements ResponseWriter.
-//
-// Note that updates to the headers will not be reflected in child
-// ResponseWriters until 'Write' or 'WriteHeaders' are called.
-func (m *MultiResponseWriter) Header() http.Header {
-	return m.header
-}
-
-func (m *MultiResponseWriter) mirrorHeaders() {
-	for _, rw := range m.rws {
-		theirs := rw.Header()
-		for key := range theirs {
-			theirs.Del(key)
-		}
-		for key, value := range m.header {
-			theirs[key] = value
-		}
-	}
-}
-
-func (m *MultiResponseWriter) Write(data []byte) (int, error) {
-	// The contract of 'Write' has it set headers and call WriteHeader under
-	// certain circmustances. We ignore that here, as we assume that all the
-	// underlying implementations do that for us.
-	m.mirrorHeaders()
-	for _, rw := range m.rws {
-		n, err := rw.Write(data)
-		if err != nil {
-			return n, err
-		}
-		if n < len(data) {
-			return n, io.ErrShortWrite
-		}
-	}
-	return len(data), nil
-}
-
-// WriteHeader writes the HTTP response header.
-func (m *MultiResponseWriter) WriteHeader(statusCode int) {
-	m.mirrorHeaders()
-	for _, rw := range m.rws {
-		rw.WriteHeader(statusCode)
-	}
-}
-
-// Hijack hijacks the first response writer that is a Hijacker.
-func (m *MultiResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	for _, rw := range m.rws {
-		hj, ok := rw.(http.Hijacker)
-		if ok {
-			return hj.Hijack()
-		}
-	}
-	return nil, nil, fmt.Errorf("MultiResponseWriter: can't cast any responses to Hijacker")
-}
-
-// badResponseLogger is an http.ResponseWriter that logs response headers and
-// some of the body when the response is erroneous (i.e. a 5xx).
-//
-// Using this means holding an extra copy of the request and response headers
-// in memory.
-type badResponseLogger struct {
+// badResponseLoggingWriter writes the body of "bad" responses (i.e. 5xx
+// responses) to a buffer.
+type badResponseLoggingWriter struct {
+	rw            http.ResponseWriter
 	buffer        bytes.Buffer
 	logBody       bool
 	bodyBytesLeft int
 	statusCode    int
 }
 
-// newBadResponseLogger makes a new badResponseLogger.
-func newBadResponseLogger() *badResponseLogger {
-	return &badResponseLogger{
+// newBadResponseLoggingWriter makes a new badResponseLoggingWriter.
+func newBadResponseLoggingWriter(rw http.ResponseWriter) *badResponseLoggingWriter {
+	return &badResponseLoggingWriter{
+		rw:            rw,
 		logBody:       false,
 		bodyBytesLeft: maxResponseBodyInLogs,
 	}
 }
 
-func (b *badResponseLogger) dumpResponse() []byte {
-	return b.buffer.Bytes()
+// Header returns the header map that will be sent by WriteHeader.
+// Implements ResponseWriter.
+func (b *badResponseLoggingWriter) Header() http.Header {
+	return b.rw.Header()
 }
 
-// Header implements http.ResponseWriter.
-func (b *badResponseLogger) Header() http.Header {
-	return http.Header{}
+// Write writes HTTP response data.
+func (b *badResponseLoggingWriter) Write(data []byte) (int, error) {
+	n, err := b.rw.Write(data)
+	if b.logBody {
+		b.captureResponseBody(data)
+	}
+	return n, err
 }
 
-// WriteHeader implements http.ResponseWriter. It will immediately log the
-// response headers if `statusCode` is a 5XX.
-func (b *badResponseLogger) WriteHeader(statusCode int) {
+// WriteHeader writes the HTTP response header.
+func (b *badResponseLoggingWriter) WriteHeader(statusCode int) {
 	b.statusCode = statusCode
 	if statusCode >= 500 {
 		b.logBody = true
 	}
+	b.rw.WriteHeader(statusCode)
 }
 
-// Write implements http.ResponseWriter.
-func (b *badResponseLogger) Write(data []byte) (int, error) {
-	// If we haven't written the headers yet, then Write is supposed to call
-	// WriteHeader with http.StatusOK. Since we don't want to do anything in
-	// that case (this struct is for *bad* responses only), we don't need to
-	// track whether or not we've called WriteHeader.
-	if !b.logBody {
-		// We don't need to log anything, so lie and say that we wrote
-		// everything, making this effectively a no-op.
-		return len(data), nil
+// Hijack hijacks the first response writer that is a Hijacker.
+func (b *badResponseLoggingWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := b.rw.(http.Hijacker)
+	if ok {
+		return hj.Hijack()
 	}
+	return nil, nil, fmt.Errorf("badResponseLoggingWriter: can't cast underlying response writer to Hijacker")
+}
 
+func (b *badResponseLoggingWriter) dumpResponseBody() []byte {
+	return b.buffer.Bytes()
+}
+
+func (b *badResponseLoggingWriter) captureResponseBody(data []byte) {
 	if len(data) > b.bodyBytesLeft {
 		b.buffer.Write(data[:b.bodyBytesLeft])
 		b.buffer.WriteString("...")
@@ -146,7 +78,4 @@ func (b *badResponseLogger) Write(data []byte) (int, error) {
 		b.buffer.Write(data)
 		b.bodyBytesLeft -= len(data)
 	}
-	// As far as any caller is concerned, we've written the whole response.
-	// There has been no error, nor a short write. Everything is fine.
-	return len(data), nil
 }


### PR DESCRIPTION
Part of https://github.com/weaveworks/service/issues/1233 

This is kind of a significant change, as it intercepts *all* incoming requests. I haven't done much in the way of testing.

Also changes the logging order slightly. Previously, when `LogRequestHeaders` was on, we would log headers then request/response summary (method, status, etc). Now, we log method, status, etc. _then_ headers.