### PR TITLE
Add http package so that http/client is available

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -1,0 +1,1 @@
+package http


### PR DESCRIPTION
This was a mistake in #43, without this the client package isn't available through dep