### PR TITLE
Include the orgID when logging gRPC calls

### DIFF
--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -6,6 +6,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
+	"github.com/weaveworks/common/logging"
 )
 
 const gRPC = "gRPC"
@@ -14,10 +16,11 @@ const gRPC = "gRPC"
 var ServerLoggingInterceptor = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	begin := time.Now()
 	resp, err := handler(ctx, req)
+	entry := logging.With(ctx).WithFields(log.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
 	if err != nil {
-		log.Warnf("%s %s (%v) %s", gRPC, info.FullMethod, err, time.Since(begin))
+		entry.WithError(err).Warn(gRPC)
 	} else {
-		log.Debugf("%s %s (success) %s", gRPC, info.FullMethod, time.Since(begin))
+		entry.Debugf("%s (success)", gRPC)
 	}
 	return resp, err
 }


### PR DESCRIPTION
And also emit the method and duration as fields so they can be parsed out

The code to generate the log entry is adapted from https://github.com/weaveworks/cortex/pull/452, which does the same thing for the Prometheus log interface.