### PR TITLE
Move 429 results from Error to Debug

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -32,7 +32,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		}
 		i := &interceptor{ResponseWriter: w, statusCode: http.StatusOK}
 		next.ServeHTTP(i, r)
-		if 100 <= i.statusCode && i.statusCode < 400 {
+		if 100 <= i.statusCode && (i.statusCode < 400 || i.statusCode < 429) {
 			log.Debugf("%s %s (%d) %s", r.Method, uri, i.statusCode, time.Since(begin))
 		} else {
 			log.Warnf("%s %s (%d) %s", r.Method, uri, i.statusCode, time.Since(begin))


### PR DESCRIPTION
429 indicates an over-limit condition which will have been logged by the component that detected it, so we don't need to log it again on the calling side.

Example:

```
{"log":"time=\"2017-07-15T21:26:35Z\" level=warning msg=\"gRPC /cortex.Ingester/Push (rpc error: code = Code(429) desc = per-metric series limit exceeded) 2.412325ms\" \n",[...]{"name":"ingester"}
{"log":"WARN: 2017/07/17 12:22:03.256129 POST /api/prom/push (429) 11.665082ms\n",[...],"container_name":"authfe"}
```