### PR TITLE
Add option to not register instrumentation routes.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,7 @@ type Config struct {
 	HTTPListenPort   int
 	GRPCListenPort   int
 
-	DontRegisterInstrumentation bool
+	RegisterInstrumentation bool
 
 	ServerGracefulShutdownTimeout time.Duration
 	HTTPServerReadTimeout         time.Duration
@@ -55,6 +55,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.HTTPListenPort, "server.http-listen-port", 80, "HTTP server listen port.")
 	f.IntVar(&cfg.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
+	f.BoolVar(&cfg.RegisterInstrumentation, "server.register-instrumentation", true, "Register the intrumentation handlers (/metrics etc).")
 	f.DurationVar(&cfg.ServerGracefulShutdownTimeout, "server.graceful-shutdown-timeout", 5*time.Second, "Timeout for graceful shutdowns")
 	f.DurationVar(&cfg.HTTPServerReadTimeout, "server.http-read-timeout", 5*time.Second, "Read timeout for HTTP server")
 	f.DurationVar(&cfg.HTTPServerWriteTimeout, "server.http-write-timeout", 5*time.Second, "Write timeout for HTTP server")
@@ -113,7 +114,7 @@ func New(cfg Config) (*Server, error) {
 
 	// Setup HTTP server
 	router := mux.NewRouter()
-	if !cfg.DontRegisterInstrumentation {
+	if cfg.RegisterInstrumentation {
 		RegisterInstrumentation(router)
 	}
 	httpMiddleware := []middleware.Interface{


### PR DESCRIPTION
So Server can be used for internet-facing services.

Default of false preserves existing behaviour.