### PR TITLE
Log the userID & orgID if we have it, not if we don't

### DIFF
--- a/user/logging.go
+++ b/user/logging.go
@@ -10,11 +10,11 @@ import (
 func LogFields(ctx context.Context) log.Fields {
 	fields := log.Fields{}
 	userID, err := ExtractUserID(ctx)
-	if err != nil {
+	if err == nil {
 		fields["userID"] = userID
 	}
 	orgID, err := ExtractOrgID(ctx)
-	if err != nil {
+	if err == nil {
 		fields["orgID"] = orgID
 	}
 	return fields


### PR DESCRIPTION
I was wondering why the billing API never logged anything helpful...