### PR TITLE
Add ConfigFromURL helper function

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// ConfigFromURL returns AWS config from given URL. It expects escaped
+// AWS Access key ID & Secret Access Key to be encoded in the URL. It
+// also expects region specified as a host (letting AWS generate full
+// endpoint) or fully valid endpoint with dummy region assumed (e.g
+// for URLs to emulated services).
+func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
+	if awsURL.User == nil {
+		return nil, fmt.Errorf("must specify escaped Access Key & Secret Access in URL")
+	}
+
+	password, _ := awsURL.User.Password()
+	creds := credentials.NewStaticCredentials(awsURL.User.Username(), password, "")
+	config := aws.NewConfig().
+		WithCredentials(creds).
+		// Use a custom http.Client with the golang defaults but also specifying
+		// MaxIdleConnsPerHost because of a bug in golang https://github.com/golang/go/issues/13801
+		// where MaxIdleConnsPerHost does not work as expected.
+		WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+					DualStack: true,
+				}).DialContext,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				MaxIdleConnsPerHost:   100,
+				TLSHandshakeTimeout:   3 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		})
+	if strings.Contains(awsURL.Host, ".") {
+		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion("dummy"), nil
+	}
+
+	// Let AWS generate default endpoint based on region passed as a host in URL.
+	return config.WithRegion(awsURL.Host), nil
+}

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -1,0 +1,89 @@
+package aws
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAWSConfigFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		url            string
+		expectedKey    string
+		expectedSecret string
+		expectedRegion string
+		expectedEp     string
+
+		expectedNotSpecifiedUserErr bool
+	}{
+		{
+			"s3://abc:123@s3.default.svc.cluster.local:4569",
+			"abc",
+			"123",
+			"dummy",
+			"http://s3.default.svc.cluster.local:4569",
+			false,
+		},
+		{
+			"dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex",
+			"user",
+			"pass",
+			"dummy",
+			"http://dynamodb.default.svc.cluster.local:8000",
+			false,
+		},
+		{
+			// Not escaped password.
+			"s3://abc:123/@s3.default.svc.cluster.local:4569",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+		{
+			// Not escaped username.
+			"s3://abc/:123@s3.default.svc.cluster.local:4569",
+			"",
+			"",
+			"",
+			"",
+			true,
+		},
+		{
+			"s3://keyWithEscapedSlashAtTheEnd%2F:%24%2C%26%2C%2B%2C%27%2C%2F%2C%3A%2C%3B%2C%3D%2C%3F%2C%40@eu-west-2/bucket1",
+			"keyWithEscapedSlashAtTheEnd/",
+			"$,&,+,',/,:,;,=,?,@",
+			"eu-west-2",
+			"",
+			false,
+		},
+	} {
+		parsedURL, err := url.Parse(tc.url)
+		require.NoError(t, err)
+
+		cfg, err := ConfigFromURL(parsedURL)
+		if tc.expectedNotSpecifiedUserErr {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+
+		require.NotNil(t, cfg.Credentials)
+		val, err := cfg.Credentials.Get()
+		require.NoError(t, err)
+
+		assert.Equal(t, tc.expectedKey, val.AccessKeyID)
+		assert.Equal(t, tc.expectedSecret, val.SecretAccessKey)
+
+		require.NotNil(t, cfg.Region)
+		assert.Equal(t, tc.expectedRegion, *cfg.Region)
+
+		if tc.expectedEp != "" {
+			require.NotNil(t, cfg.Endpoint)
+			assert.Equal(t, tc.expectedEp, *cfg.Endpoint)
+		}
+	}
+}


### PR DESCRIPTION
Code was extracted from weaveworks/cortex

This is so we can re-use the fix from https://github.com/weaveworks/cortex/pull/537 in Scope and elsewhere

Note it does not include the line that disables retries; that is particular to Cortex and has to be added back there.