### PR TITLE
Use new gRPC APIs

### DIFF
--- a/user/grpc.go
+++ b/user/grpc.go
@@ -8,7 +8,7 @@ import (
 // ExtractFromGRPCRequest extracts the user ID from the request metadata and returns
 // the user ID and a context with the user ID injected.
 func ExtractFromGRPCRequest(ctx context.Context) (string, context.Context, error) {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return "", ctx, ErrNoOrgID
 	}
@@ -28,7 +28,7 @@ func InjectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
 		return ctx, err
 	}
 
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		md = metadata.New(map[string]string{})
 	}
@@ -44,7 +44,7 @@ func InjectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
 	} else {
 		md = md.Copy()
 		md[lowerOrgIDHeaderName] = []string{orgID}
-		newCtx = metadata.NewContext(ctx, md)
+		newCtx = metadata.NewOutgoingContext(ctx, md)
 	}
 
 	return newCtx, nil


### PR DESCRIPTION
https://github.com/grpc/grpc-go/pull/1157 changed the APIs for getting
metadata from contexts and making contexts from metadata.

This PR updates common to rely on the new library.

Means that anyone who vendors common will need a recent grpc-go too.