### PR TITLE
Log request headers, response headers and some body as warning on 500s

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -46,7 +46,9 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			}
 		} else {
 			logWithRequest(r).Warnf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
-			logWithRequest(r).Warnf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))
+			if headers != nil {
+				logWithRequest(r).Warnf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))
+			}
 			logWithRequest(r).Warnf("Response: %s", buf.Bytes())
 		}
 	})

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -39,7 +39,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		wrapped := newBadResponseLoggingWriter(w, &buf)
 		next.ServeHTTP(wrapped, r)
 		statusCode := wrapped.statusCode
-		if 100 <= statusCode && statusCode < 400 {
+		if 100 <= statusCode && statusCode < 500 {
 			logWithRequest(r).Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
 			if l.LogRequestHeaders && headers != nil {
 				logWithRequest(r).Debugf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+const (
+	maxResponseBodyInLogs = 4096 // At most 4k bytes from response bodies in our logs.
+)
+
+// badResponseLoggingWriter writes the body of "bad" responses (i.e. 5xx
+// responses) to a buffer.
+type badResponseLoggingWriter struct {
+	rw            http.ResponseWriter
+	buffer        io.Writer
+	logBody       bool
+	bodyBytesLeft int
+	statusCode    int
+}
+
+// newBadResponseLoggingWriter makes a new badResponseLoggingWriter.
+func newBadResponseLoggingWriter(rw http.ResponseWriter, buffer io.Writer) *badResponseLoggingWriter {
+	return &badResponseLoggingWriter{
+		rw:            rw,
+		logBody:       false,
+		bodyBytesLeft: maxResponseBodyInLogs,
+	}
+}
+
+// Header returns the header map that will be sent by WriteHeader.
+// Implements ResponseWriter.
+func (b *badResponseLoggingWriter) Header() http.Header {
+	return b.rw.Header()
+}
+
+// Write writes HTTP response data.
+func (b *badResponseLoggingWriter) Write(data []byte) (int, error) {
+	n, err := b.rw.Write(data)
+	if b.logBody {
+		b.captureResponseBody(data)
+	}
+	return n, err
+}
+
+// WriteHeader writes the HTTP response header.
+func (b *badResponseLoggingWriter) WriteHeader(statusCode int) {
+	b.statusCode = statusCode
+	if statusCode >= 500 {
+		b.logBody = true
+	}
+	b.rw.WriteHeader(statusCode)
+}
+
+// Hijack hijacks the first response writer that is a Hijacker.
+func (b *badResponseLoggingWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := b.rw.(http.Hijacker)
+	if ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("badResponseLoggingWriter: can't cast underlying response writer to Hijacker")
+}
+
+func (b *badResponseLoggingWriter) captureResponseBody(data []byte) {
+	if len(data) > b.bodyBytesLeft {
+		b.buffer.Write(data[:b.bodyBytesLeft])
+		io.WriteString(b.buffer, "...")
+		b.bodyBytesLeft = 0
+		b.logBody = false
+	} else {
+		b.buffer.Write(data)
+		b.bodyBytesLeft -= len(data)
+	}
+}

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -39,6 +39,11 @@ func (b *badResponseLoggingWriter) Header() http.Header {
 
 // Write writes HTTP response data.
 func (b *badResponseLoggingWriter) Write(data []byte) (int, error) {
+	if b.statusCode == 0 {
+		// WriteHeader has (probably) not been called, so we need to call it with StatusOK to fuflil the interface contract.
+		// https://godoc.org/net/http#ResponseWriter
+		b.WriteHeader(http.StatusOK)
+	}
 	n, err := b.rw.Write(data)
 	if b.logBody {
 		b.captureResponseBody(data)


### PR DESCRIPTION
Re-do of https://github.com/weaveworks/common/pull/41 which was reverted in #56 because I thought it introduced an error that stopped the users service from working. Actually, it was because of #47, which we've fixed with weaveworks/service#1374

This is mostly the same as #41, but
- only logs 500s
- fixes a logic bug such that we don't try to log `nil` headers
- re-introduces a StatusOK thingummy, so we don't log huge amounts of information on successful requests