### PR TITLE
Add notification client library

### DIFF
--- a/notifications/README.md
+++ b/notifications/README.md
@@ -1,0 +1,49 @@
+## Notifications
+
+The `notifications` package is a client library for the [weaveworks/notifications](https://github.com/weaveworks/notification) service.
+
+
+```golang
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/weaveworks/common/notifications"
+)
+
+func main() {
+	url := "http://eventmanager.notification.svc.cluster.local.:80"
+	sender := notifications.CreateSender(url)
+
+	instanceID := "1"
+	instanceName := "super-cool-instance"
+
+	// Format your message according to the different channels to which it will be sent
+	text := fmt.Sprintf("Instance %s has exploded", instanceName)
+	html := fmt.Sprintf("Instance <b>%s</b> has exploded", instanceName)
+	markdown := fmt.Sprintf("Instance _%s_ has exploded", instanceName)
+
+	timestamp := time.Now()
+
+	message := notifications.Message{
+		Browser: notifications.BrowserMessage{
+			Type:      "critical",
+			Text:      text,
+			Timestamp: timestamp,
+		},
+		Email: notifications.EmailMessage{
+			Subject: "Explosion!",
+			Body:    html,
+		},
+		Slack: notifications.SlackMessage{
+			Text: markdown,
+		},
+	}
+
+	if err := sender.SendEvent("critical", instanceID, timestamp, &message); err != nil {
+		fmt.Printf("Error: %v", err)
+	}
+}
+```

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -16,43 +16,44 @@ type Sender struct {
 }
 
 // EmailMessage contains the required fields for formatting email messages
-type EmailMessage struct {
+type emailMessage struct {
 	Subject string `json:"subject"`
 	Body    string `json:"body"`
 }
 
-type Attachment struct {
-	Fallback string   `json:"fallback,omitempty"`
-	Text     string   `json:"text"`
-	Color    string   `json:"color,omitempty"`
-	Markdown []string `json:"mrkdwn_in,omitempty"`
+type attachment struct {
+	Fallback   string   `json:"fallback,omitempty"`
+	Text       string   `json:"text"`
+	Color      string   `json:"color,omitempty"`
+	MarkdownIn []string `json:"mrkdwn_in,omitempty"`
 }
 
 // SlackMessage contains the required fields for formatting slack messages
-type SlackMessage struct {
+type slackMessage struct {
 	Text        string       `json:"text"`
-	Attachments []Attachment `json:"attachments"`
+	Attachments []attachment `json:"attachments"`
 }
 
 // BrowserMessage contains the required fields for formatting browser notifications
-type BrowserMessage struct {
+type browserMessage struct {
 	Type      string    `json:"type"`
 	Text      string    `json:"text"`
 	Timestamp time.Time `json:"timestamp"`
 }
 
 // Message contains the mappings for formatting notification messages
-type Message struct {
-	Browser BrowserMessage `json:"browser"`
-	Slack   SlackMessage   `json:"slack"`
-	Email   EmailMessage   `json:"email"`
+type message struct {
+	Browser  browserMessage `json:"browser"`
+	Slack    slackMessage   `json:"slack"`
+	Email    emailMessage   `json:"email"`
+	Fallback string         `json:"fallback"`
 }
 
 type event struct {
 	Type       string    `json:"type"`
 	InstanceID string    `json:"instance_id"`
 	Timestamp  time.Time `json:"timestamp"`
-	Messages   Message   `json:"messages"`
+	Messages   message   `json:"messages"`
 }
 
 // CreateSender creates a Sender
@@ -62,28 +63,30 @@ func CreateSender(url string) Sender {
 	}
 }
 
-func createMessage(eventType string, timestamp time.Time, text string, attachments []string) Message {
-	var slackAttachments []Attachment
+func createMessage(eventType string, timestamp time.Time, text string, attachments []string) message {
+	var slackAttachments []attachment
 
 	for i := range attachments {
-		a := attachments[i]
-		slackAttachments = append(slackAttachments, Attachment{
-			Text:     text,
-			Fallback: text,
-			Markdown: []string{a},
+		raw := attachments[i]
+		slackAttachments = append(slackAttachments, attachment{
+			Fallback:   text,
+			Text:       raw,
+			Color:      "#439FE0",
+			MarkdownIn: []string{"text"},
 		})
 	}
-	return Message{
-		Browser: BrowserMessage{
+	return message{
+		Fallback: text,
+		Browser: browserMessage{
 			Type:      eventType,
 			Text:      text,
 			Timestamp: timestamp,
 		},
-		Email: EmailMessage{
+		Email: emailMessage{
 			Subject: eventType,
 			Body:    text,
 		},
-		Slack: SlackMessage{
+		Slack: slackMessage{
 			Text:        text,
 			Attachments: slackAttachments,
 		},

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,0 +1,88 @@
+package notifications
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Sender contains the configuration information to send events to the notification service
+type Sender struct {
+	URL string
+}
+
+// EmailMessage contains the required fields for formatting email messages
+type EmailMessage struct {
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
+}
+
+// SlackMessage contains the required fields for formatting slack messages
+type SlackMessage struct {
+	Text string `json:"text"`
+}
+
+// BrowserMessage contains the required fields for formatting browser notifications
+type BrowserMessage struct {
+	Type      string    `json:"type"`
+	Text      string    `json:"text"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Message contains the mappings for formatting notification messages
+type Message struct {
+	Browser BrowserMessage `json:"browser"`
+	Slack   SlackMessage   `json:"slack"`
+	Email   EmailMessage   `json:"email"`
+}
+
+type event struct {
+	Type       string    `json:"type"`
+	InstanceID string    `json:"instance_id"`
+	Timestamp  time.Time `json:"timestamp"`
+	Messages   *Message  `json:"messages"`
+}
+
+// CreateSender creates a Sender
+func CreateSender(url string) Sender {
+	return Sender{
+		URL: url,
+	}
+}
+
+// SendEvent sends an event to the notification service.
+func (s *Sender) SendEvent(et string, instance string, t time.Time, msg *Message) error {
+	e := event{
+		Type:       et,
+		InstanceID: instance,
+		Timestamp:  t,
+		Messages:   msg,
+	}
+
+	eventBytes, err := json.Marshal(e)
+	if err != nil {
+		return errors.Wrapf(err, "Cannot marshal event to []byte %s", err)
+	}
+
+	postEventURL := fmt.Sprintf("%s/api/notification/events", s.URL)
+
+	req, err := http.NewRequest("POST", postEventURL, bytes.NewBuffer(eventBytes))
+	if err != nil {
+		return errors.Wrapf(err, "POST request error to URL %s", s.URL)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "Failed to POST event")
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/weaveworks/notification/issues/21

Adds a first iteration of a client library for notifications. This intentionally contains very little abstraction and only be used for an initial non-customer-facing service, such as `service-ui-kicker`.