### PR TITLE
If orgID already present, rename instead of reject

### DIFF
--- a/user/grpc.go
+++ b/user/grpc.go
@@ -33,19 +33,14 @@ func InjectIntoGRPCRequest(ctx context.Context) (context.Context, error) {
 		md = metadata.New(map[string]string{})
 	}
 	newCtx := ctx
+	md = md.Copy()
 	if orgIDs, ok := md[lowerOrgIDHeaderName]; ok {
-		if len(orgIDs) == 1 {
-			if orgIDs[0] != orgID {
-				return ctx, ErrDifferentOrgIDPresent
-			}
-		} else {
-			return ctx, ErrTooManyOrgIDs
+		if len(orgIDs) != 1 || orgIDs[0] != orgID {
+			md[lowerOrigOrgIDHeaderName] = orgIDs
 		}
-	} else {
-		md = md.Copy()
-		md[lowerOrgIDHeaderName] = []string{orgID}
-		newCtx = metadata.NewOutgoingContext(ctx, md)
 	}
+	md[lowerOrgIDHeaderName] = []string{orgID}
+	newCtx = metadata.NewOutgoingContext(ctx, md)
 
 	return newCtx, nil
 }

--- a/user/http.go
+++ b/user/http.go
@@ -11,8 +11,13 @@ const (
 	orgIDHeaderName  = "X-Scope-OrgID"
 	userIDHeaderName = "X-Scope-UserID"
 
+	// origOrgIDHeaderName is used when a request already contains the header
+	origOrgIDHeaderName  = "X-Orig-Scope-OrgID"
+	origUserIDHeaderName = "X-Orig-Scope-UserID"
+
 	// LowerOrgIDHeaderName as gRPC / HTTP2.0 headers are lowercased.
-	lowerOrgIDHeaderName = "x-scope-orgid"
+	lowerOrgIDHeaderName     = "x-scope-orgid"
+	lowerOrigOrgIDHeaderName = "x-orig-scope-orgid"
 )
 
 // ExtractOrgIDFromHTTPRequest extracts the org ID from the request headers and returns
@@ -33,7 +38,7 @@ func InjectOrgIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
 	}
 	existingID := r.Header.Get(orgIDHeaderName)
 	if existingID != "" && existingID != orgID {
-		return ErrDifferentOrgIDPresent
+		r.Header.Set(origOrgIDHeaderName, existingID)
 	}
 	r.Header.Set(orgIDHeaderName, orgID)
 	return nil
@@ -57,7 +62,7 @@ func InjectUserIDIntoHTTPRequest(ctx context.Context, r *http.Request) error {
 	}
 	existingID := r.Header.Get(userIDHeaderName)
 	if existingID != "" && existingID != userID {
-		return ErrDifferentUserIDPresent
+		r.Header.Set(origUserIDHeaderName, existingID)
 	}
 	r.Header.Set(userIDHeaderName, userID)
 	return nil

--- a/user/id.go
+++ b/user/id.go
@@ -16,13 +16,8 @@ const (
 
 // Errors that we return
 const (
-	ErrNoOrgID               = errors.Error("no org id")
-	ErrDifferentOrgIDPresent = errors.Error("different org ID already present")
-	ErrTooManyOrgIDs         = errors.Error("multiple org IDs present")
-
-	ErrNoUserID               = errors.Error("no user id")
-	ErrDifferentUserIDPresent = errors.Error("different user ID already present")
-	ErrTooManyUserIDs         = errors.Error("multiple user IDs present")
+	ErrNoOrgID  = errors.Error("no org id")
+	ErrNoUserID = errors.Error("no user id")
 )
 
 // ExtractOrgID gets the org ID from the context.


### PR DESCRIPTION
As discussed in a related private change, I am trying a certain request from an internal service which results in this header already being present.

If we simply rename the offending header, rather than reject the request, then things should work. 