### PR TITLE
Add Prometheus metrics for number of log messages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -116,12 +116,6 @@
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
-  name = "github.com/marccarre/promrus"
-  packages = ["."]
-  revision = "6f9713cf3e9bc69424a25d8d0f696f7ce7b4ff2b"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   revision = "d228849504861217f796da67fae4f6e347643f15"
@@ -242,6 +236,12 @@
   revision = "17ff1516db3dffe25452b4cbf6e6412f303cddea"
 
 [[projects]]
+  name = "github.com/weaveworks/promrus"
+  packages = ["."]
+  revision = "6f9713cf3e9bc69424a25d8d0f696f7ce7b4ff2b"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -286,6 +286,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a3ad52c3fcabeb3e024e95fba61b5871585cda618b02d074562c55455874008a"
+  inputs-digest = "f0129b411593e3ada6198352b8c9d637371fe1cdf2d606a29779ced5ac1b3153"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,6 +122,12 @@
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  name = "github.com/marccarre/promrus"
+  packages = ["."]
+  revision = "6f9713cf3e9bc69424a25d8d0f696f7ce7b4ff2b"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
   revision = "d228849504861217f796da67fae4f6e347643f15"
@@ -224,6 +230,12 @@
   revision = "2f561e34ecb6206fcad82f0c5842379188d8db40"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
+  version = "v1.0.3"
+
+[[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert","require"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
@@ -237,6 +249,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "da118f7b8e5954f39d0d2130ab35d4bf0e3cb344"
@@ -244,7 +262,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = ["unix","windows"]
   revision = "9f30dcbe5be197894515a338a9bda9253567ea8f"
 
 [[projects]]
@@ -274,6 +292,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "57f4df946c97e1fcb83ee6757a832e47d43fc3e3356613cd4a632a9b321b92c7"
+  inputs-digest = "b602db993a398a746557adcec269b8beaae300e837297184dd667bfe2ddcaddf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,12 +8,6 @@
   version = "v1.11.0"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = [".","hooks/test"]
-  revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
-  version = "v0.11.5"
-
-[[projects]]
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
   revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
@@ -231,7 +225,7 @@
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
-  packages = ["."]
+  packages = [".","hooks/test"]
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
 
@@ -292,6 +286,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b602db993a398a746557adcec269b8beaae300e837297184dd667bfe2ddcaddf"
+  inputs-digest = "a3ad52c3fcabeb3e024e95fba61b5871585cda618b02d074562c55455874008a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type backoff struct {

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/Sirupsen/logrus/hooks/test"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/weaveworks/common/backoff"
 )
 

--- a/httpgrpc/httpgrpc.go
+++ b/httpgrpc/httpgrpc.go
@@ -3,9 +3,9 @@ package httpgrpc
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	log "github.com/sirupsen/logrus"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/status"
 )

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -10,9 +10,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/marccarre/promrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/promrus"
 )
 
 const (

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -10,8 +10,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/marccarre/promrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/common/user"
 )
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/marccarre/promrus"
 	"github.com/weaveworks/common/user"
 )
 
@@ -27,6 +28,11 @@ func Setup(logLevel string) error {
 	}
 	log.SetLevel(level)
 	log.SetFormatter(&textFormatter{})
+	hook, err := promrus.NewPrometheusHook() // Expose number of log messages as Prometheus metrics.
+	if err != nil {
+		return err
+	}
+	log.AddHook(hook)
 	return nil
 }
 

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httputil"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/weaveworks/common/user"
 )

--- a/middleware/path_rewrite.go
+++ b/middleware/path_rewrite.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"regexp"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // PathRewrite supports regex matching and replace on Request URIs

--- a/sanitize/sanitize.go
+++ b/sanitize/sanitize.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // URL returns a function that sanitizes a URL string. It lets underspecified

--- a/server/server.go
+++ b/server/server.go
@@ -8,13 +8,13 @@ import (
 	_ "net/http/pprof" // anonymous import to get the pprof handler registered
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/mwitkow/go-grpc-middleware"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 

--- a/user/logging.go
+++ b/user/logging.go
@@ -3,7 +3,7 @@ package user
 import (
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // LogFields returns user and org information from the context as log fields.


### PR DESCRIPTION
[Promrus](https://github.com/marccarre/promrus/) is a Logrus hook to expose the number of log messages as [Prometheus](https://prometheus.io/) metrics:
```
log_messages{level="debug"}
log_messages{level="info"}
log_messages{level="warning"}
log_messages{level="error"}
```

Added dependency using:
```
$ dep ensure github.com/weaveworks/promrus@v1.0.0 && dep ensure && dep prune
```


Fixed casing in `logrus` imports, causing the following issue:
```
middleware/grpc_logging.go:10:2: case-insensitive import collision:
"github.com/weaveworks/common/vendor/github.com/Sirupsen/logrus" and
"github.com/weaveworks/common/vendor/github.com/sirupsen/logrus"
```
by:
- changing `import` statements from `Sirupsen/logrus` to `sirupsen/logrus`, as per [the official documentation](https://github.com/sirupsen/logrus), and
- running `dep ensure && dep prune`.