### PR TITLE
Stop reporting zero status

### DIFF
--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -93,4 +96,32 @@ func MakeLabelValue(path string) string {
 		result = "root"
 	}
 	return result
+}
+
+// interceptor implements WriteHeader to intercept status codes. WriteHeader
+// may not be called on success, so initialize statusCode with the status you
+// want to report on success, i.e. http.StatusOK.
+//
+// interceptor also implements net.Hijacker, to let the downstream Handler
+// hijack the connection. This is needed, for example, for working with websockets.
+type interceptor struct {
+	http.ResponseWriter
+	statusCode int
+	recorded   bool
+}
+
+func (i *interceptor) WriteHeader(code int) {
+	if !i.recorded {
+		i.statusCode = code
+		i.recorded = true
+	}
+	i.ResponseWriter.WriteHeader(code)
+}
+
+func (i *interceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := i.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("interceptor: can't cast parent ResponseWriter to Hijacker")
+	}
+	return hj.Hijack()
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -1,10 +1,7 @@
 package middleware
 
 import (
-	"bufio"
 	"bytes"
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"time"
@@ -57,31 +54,3 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 // Logging middleware logs each HTTP request method, path, response code and
 // duration for all HTTP requests.
 var Logging = Log{}
-
-// interceptor implements WriteHeader to intercept status codes. WriteHeader
-// may not be called on success, so initialize statusCode with the status you
-// want to report on success, i.e. http.StatusOK.
-//
-// interceptor also implements net.Hijacker, to let the downstream Handler
-// hijack the connection. This is needed, for example, for working with websockets.
-type interceptor struct {
-	http.ResponseWriter
-	statusCode int
-	recorded   bool
-}
-
-func (i *interceptor) WriteHeader(code int) {
-	if !i.recorded {
-		i.statusCode = code
-		i.recorded = true
-	}
-	i.ResponseWriter.WriteHeader(code)
-}
-
-func (i *interceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hj, ok := i.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, fmt.Errorf("interceptor: can't cast parent ResponseWriter to Hijacker")
-	}
-	return hj.Hijack()
-}

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -83,7 +83,5 @@ func (i *interceptor) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("interceptor: can't cast parent ResponseWriter to Hijacker")
 	}
-	// Set the status code because further interactions will bypass this object
-	i.statusCode = http.StatusSwitchingProtocols
 	return hj.Hijack()
 }

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -29,6 +29,7 @@ func newBadResponseLoggingWriter(rw http.ResponseWriter, buffer io.Writer) *badR
 		buffer:        buffer,
 		logBody:       false,
 		bodyBytesLeft: maxResponseBodyInLogs,
+		statusCode:    http.StatusOK,
 	}
 }
 


### PR DESCRIPTION
Fixes #68 
Reverts #69 since it was [misguided](https://github.com/weaveworks/common/issues/68#issuecomment-336499041)

I moved `interceptor` to beside where it is used because the location in `logging.go` confused me,
and applied the advice from `interceptor` to `badResponseLoggingWriter` - 

> `WriteHeader` may not be called on success, so initialize `statusCode` with the status you want to report on success, i.e. `http.StatusOK`.

And I've even tried running it.