### PR TITLE
Add error message to OpenTracing span

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	oldcontext "golang.org/x/net/context"
 )
@@ -140,6 +141,7 @@ func CollectedRequest(ctx context.Context, method string, col Collector, toStatu
 
 	if err != nil {
 		ext.Error.Set(sp, true)
+		sp.LogFields(otlog.Error(err))
 	}
 	sp.Finish()
 


### PR DESCRIPTION
This is handy when debugging.  ~I limit the length arbitrarily just in case someone has dumped their life-story into the error string.~