### PR TITLE
Extend histogram buckets for a server up to 100 seconds

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -11,6 +11,10 @@ import (
 	oldcontext "golang.org/x/net/context"
 )
 
+// DefBuckets are histogram buckets for the response time (in seconds)
+// of a network service, including one that is responding very slowly.
+var DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100}
+
 // Collector describes something that collects data before and/or after a task.
 type Collector interface {
 	Register()

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks-experiments/loki/pkg/client"
 	"github.com/weaveworks/common/httpgrpc"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
+	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/signals"
 )
@@ -95,7 +96,7 @@ func New(cfg Config) (*Server, error) {
 		Namespace: cfg.MetricsNamespace,
 		Name:      "request_duration_seconds",
 		Help:      "Time (in seconds) spent serving HTTP requests.",
-		Buckets:   prometheus.DefBuckets,
+		Buckets:   instrument.DefBuckets,
 	}, []string{"method", "route", "status_code", "ws"})
 	prometheus.MustRegister(requestDuration)
 


### PR DESCRIPTION
Previously we would clamp at 10 seconds, giving a misleading impression for things that can take a lot longer to respond.
