### PR TITLE
Let servers support gzipped gRPC

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -111,6 +111,7 @@ func New(cfg Config) (*Server, error) {
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpcMiddleware...,
 		)),
+		grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
 	)
 
 	// Setup HTTP server


### PR DESCRIPTION
A feature for larger payloads.  Whether it is used or not is controlled at the client side.
