### PR TITLE
Don't log request body and headers for 502 errors

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -36,7 +36,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		wrapped := newBadResponseLoggingWriter(w, &buf)
 		next.ServeHTTP(wrapped, r)
 		statusCode := wrapped.statusCode
-		if 100 <= statusCode && statusCode < 500 {
+		if 100 <= statusCode && statusCode < 500 || statusCode == 502 {
 			logWithRequest(r).Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
 			if l.LogRequestHeaders && headers != nil {
 				logWithRequest(r).Debugf("Is websocket request: %v\n%s", IsWSHandshakeRequest(r), string(headers))


### PR DESCRIPTION
These are not usually caused by the problems with the request, and just result in spammy logs during local development.