### PR TITLE
Add args to tracing.New to allow configurable trace sampling

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -5,23 +5,30 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	jaegercfg "github.com/uber/jaeger-client-go/config"
 )
 
 // New registers Jaeger as the OpenTracing implementation.
 // If jaegerAgentHost is an empty string, tracing is disabled.
-func New(jaegerAgentHost, serviceName, samplerType string, samplerParam float64) io.Closer {
+// Values are retrieved from environment variables, and are
+//  configurable per Cortex component
+func New(serviceName string) io.Closer {
+	jaegerAgentHost := os.Getenv("JAEGER_AGENT_HOST")
+	jaegerSamplerType := os.Getenv("JAEGER_SAMPLER_TYPE")
+	jaegerSamplerParam, _ := strconv.ParseFloat(os.Getenv("JAEGER_SAMPLER_PARAM"), 64)
+
 	if jaegerAgentHost != "" {
-		if samplerType == "" || samplerParam == 0 {
-			samplerType = "ratelimiting"
-			samplerParam = 10.0
+		if jaegerSamplerType == "" || jaegerSamplerParam == 0 {
+			jaegerSamplerType = "ratelimiting"
+			jaegerSamplerParam = 10.0
 		}
 		cfg := jaegercfg.Configuration{
 			Sampler: &jaegercfg.SamplerConfig{
 				SamplingServerURL: fmt.Sprintf("http://%s:5778/sampling", jaegerAgentHost),
-				Type:              samplerType,
-				Param:             samplerParam,
+				Type:              jaegerSamplerType,
+				Param:             jaegerSamplerParam,
 			},
 			Reporter: &jaegercfg.ReporterConfig{
 				LocalAgentHostPort: fmt.Sprintf("%s:6831", jaegerAgentHost),

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -13,6 +13,10 @@ import (
 // If jaegerAgentHost is an empty string, tracing is disabled.
 func New(jaegerAgentHost, serviceName, samplerType string, samplerParam float64) io.Closer {
 	if jaegerAgentHost != "" {
+		if samplerType == "" || samplerParam == 0 {
+			samplerType = "ratelimiting"
+			samplerParam = 10.0
+		}
 		cfg := jaegercfg.Configuration{
 			Sampler: &jaegercfg.SamplerConfig{
 				SamplingServerURL: fmt.Sprintf("http://%s:5778/sampling", jaegerAgentHost),

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -6,19 +6,18 @@ import (
 	"io/ioutil"
 	"os"
 
-	jaeger "github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
 )
 
 // New registers Jaeger as the OpenTracing implementation.
 // If jaegerAgentHost is an empty string, tracing is disabled.
-func New(jaegerAgentHost, serviceName string) io.Closer {
+func New(jaegerAgentHost, serviceName, samplerType string, samplerParam float64) io.Closer {
 	if jaegerAgentHost != "" {
 		cfg := jaegercfg.Configuration{
 			Sampler: &jaegercfg.SamplerConfig{
 				SamplingServerURL: fmt.Sprintf("http://%s:5778/sampling", jaegerAgentHost),
-				Type:              jaeger.SamplerTypeConst,
-				Param:             1,
+				Type:              samplerType,
+				Param:             samplerParam,
 			},
 			Reporter: &jaegercfg.ReporterConfig{
 				LocalAgentHostPort: fmt.Sprintf("%s:6831", jaegerAgentHost),


### PR DESCRIPTION
This commit allows Cortex systems to specify, per-service, how trace sampling should be handled in the Jaeger client. Given that `jaeger.SamplerTypeConst` yields an all-or-nothing approach to sampling, Production deployments of Cortex are effectively blocked from enabling Jaeger traces. The load generated on Jaeger Collector (and its data store) is immense with a sampling probability of 1, even for moderate-sized deployments.

There's a partner PR (https://github.com/weaveworks/cortex/pull/703) to enable Cortex components to take advantage of this, defaulting to `jaeger.SamplerTypeRateLimiting` with a param of `10.0` to yield ~10 traces per second being shipped when `JAEGER_AGENT_HOST` is set at runtime. This is easily swapped for an alternate sampling strategy, however.