### PR TITLE
Don't log full request body on failed /cortex.Ingester/Push calls

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -391,6 +391,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3cb1a35d8fac441b45239bdd9ab6ec4a89d99e8a10d2cf434ee467f962f416a3"
+  inputs-digest = "39a60544e316ef3c4186984337ab7d5044ded4853a013224618d8f924a5e9249"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -18,7 +18,11 @@ var ServerLoggingInterceptor = func(ctx context.Context, req interface{}, info *
 	resp, err := handler(ctx, req)
 	entry := logging.With(ctx).WithFields(log.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
 	if err != nil {
-		entry.WithField("request", req).WithError(err).Warn(gRPC)
+		if info.FullMethod == "/cortex.Ingester/Push" {
+			entry.WithError(err).Warn(gRPC)
+		} else {
+			entry.WithField("request", req).WithError(err).Warn(gRPC)
+		}
 	} else {
 		entry.Debugf("%s (success)", gRPC)
 	}

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -33,6 +33,3 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 	}
 	return resp, err
 }
-
-// ServerLoggingInterceptor logs gRPC requests, errors and latency. Left here for backwards compatibility
-var ServerLoggingInterceptor = GRPCServerLog{WithRequest: true}.UnaryServerInterceptor

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -12,29 +12,27 @@ import (
 
 const gRPC = "gRPC"
 
-// ServerLoggingInterceptor logs gRPC requests, errors and latency.
-var ServerLoggingInterceptor = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	begin := time.Now()
-	resp, err := handler(ctx, req)
-	entry := logging.With(ctx).WithFields(log.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
-	if err != nil {
-		entry.WithField("request", req).WithError(err).Warn(gRPC)
-	} else {
-		entry.Debugf("%s (success)", gRPC)
-	}
-	return resp, err
+// GRPCServerLog logs grpc requests, errors, and latency.
+type GRPCServerLog struct {
+	// WithRequest will log the entire request rather than just the error
+	WithRequest bool
 }
 
-// TruncatedServerLoggingInterceptor logs gRPC requests, errors and latency,
-// but omits request bodies.
-var TruncatedServerLoggingInterceptor = func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+// UnaryServerInterceptor returns an interceptor that logs gRPC requests
+func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	begin := time.Now()
 	resp, err := handler(ctx, req)
 	entry := logging.With(ctx).WithFields(log.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
 	if err != nil {
+		if s.WithRequest {
+			entry = entry.WithField("request", req)
+		}
 		entry.WithError(err).Warn(gRPC)
 	} else {
 		entry.Debugf("%s (success)", gRPC)
 	}
 	return resp, err
 }
+
+// ServerLoggingInterceptor logs gRPC requests, errors and latency. Left here for backwards compatibility
+var ServerLoggingInterceptor = GRPCServerLog{WithRequest: true}.UnaryServerInterceptor

--- a/server/server.go
+++ b/server/server.go
@@ -42,7 +42,7 @@ type Config struct {
 	GRPCListenPort   int
 
 	RegisterInstrumentation bool
-	TruncatedServerLogging  bool
+	ExcludeRequestInLog     bool
 
 	ServerGracefulShutdownTimeout time.Duration
 	HTTPServerReadTimeout         time.Duration
@@ -103,7 +103,7 @@ func New(cfg Config) (*Server, error) {
 	prometheus.MustRegister(requestDuration)
 
 	// Setup gRPC server
-	serverLog := middleware.GRPCServerLog{WithRequest: !cfg.TruncatedServerLogging}
+	serverLog := middleware.GRPCServerLog{WithRequest: !cfg.ExcludeRequestInLog}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
 		middleware.ServerInstrumentInterceptor(requestDuration),


### PR DESCRIPTION
#85 added across-the-board logging of gRPC body contents on failed requests, which blows up the Ingester logs on a failed push.

In my perusal so far, ingester push failures currently log either:
* Nothing at all about the relevant series
* All the pertinent details such as metric name, label values, latest value, incoming value, etc.

This change should simply retain the old logging behavior for ingester push failures, while still enhancing logging of other RPC failures across the system.

@bboreham, I think this may unblock https://github.com/weaveworks/cortex/pull/709 (once vendored in of course). What are your thoughts?