### PR TITLE
Add gRPC streaming middleware.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,18 +2,6 @@
 
 
 [[projects]]
-  name = "github.com/Shopify/sarama"
-  packages = ["."]
-  revision = "0fb560e5f7fbcaee2f75e3c34174320709f69944"
-  version = "v1.11.0"
-
-[[projects]]
-  name = "github.com/apache/thrift"
-  packages = ["lib/go/thrift"]
-  revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
-  version = "0.10.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/armon/go-socks5"
   packages = ["."]
@@ -26,16 +14,17 @@
     "aws/awserr",
     "aws/credentials",
     "aws/endpoints",
+    "internal/sdkio",
     "internal/shareddefaults"
   ]
-  revision = "9924c83c280264fb32f34cc5095204c451bedf0c"
-  version = "v1.10.47"
+  revision = "c7cd1ebe87257cde9b65112fc876b0339ea0ac30"
+  version = "v1.13.49"
 
 [[projects]]
   branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
   branch = "master"
@@ -50,43 +39,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/eapache/go-resiliency"
-  packages = ["breaker"]
-  revision = "6800482f2c813e689c88b7ed3282262385011890"
-  version = "v1.0.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/eapache/go-xerial-snappy"
-  packages = ["."]
-  revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
-
-[[projects]]
-  name = "github.com/eapache/queue"
-  packages = ["."]
-  revision = "ded5959c0d4e360646dc9e9908cff48666781367"
-  version = "v1.0.2"
-
-[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "20b96f641a5ea98f2f8619ff4f3e061cff4833bd"
-  version = "v1.28.2"
+  revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
+  version = "v1.36.0"
 
 [[projects]]
-  name = "github.com/go-logfmt/logfmt"
-  packages = ["."]
-  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
-  version = "v0.3.0"
-
-[[projects]]
-  name = "github.com/gogo/protobuf"
-  packages = ["proto"]
-  revision = "100ba4e885062801d56799d78530b73b178a78f3"
-  version = "v0.4"
-
-[[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -96,55 +54,38 @@
     "ptypes/empty",
     "ptypes/timestamp"
   ]
-  revision = "2bba0603135d7d7f5cb73b2125beeda19c09f4ef"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/golang/snappy"
-  packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "392c28fe23e1c45ddba891b0320b3b5df220beea"
-  version = "v1.3.0"
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
-  revision = "ef7d6c8df7564c20c0a19ed9737f6d67990c61fa"
-
-[[projects]]
-  name = "github.com/klauspost/crc32"
-  packages = ["."]
-  revision = "cb6bfca970f6908083f26f39a79009d608efd5cd"
-  version = "v1.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/kr/logfmt"
-  packages = ["."]
-  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+  revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  revision = "d228849504861217f796da67fae4f6e347643f15"
-  version = "v0.0.7"
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  revision = "fc9e8d8ef48496124e79ae0df75490096eccf6fe"
-  version = "v0.0.2"
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -159,16 +100,16 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
-  branch = "master"
   name = "github.com/mwitkow/go-grpc-middleware"
   packages = ["."]
-  revision = "164c5fae744b141cd3e4a182b40d66fd4655c822"
+  revision = "c250d6563d4d4c20252cd865923440e829844f4e"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/opentracing-contrib/go-stdlib"
   packages = ["nethttp"]
-  revision = "1de4cc2120e71f745a5810488bf64b29b6d7d9f6"
+  revision = "36723135187404d2f4002f4f189938565e64cc5c"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -177,33 +118,14 @@
     "ext",
     "log"
   ]
-  revision = "6edb48674bd9467b8e91fda004f2bd7202d60ce4"
-  version = "v1.0.1"
+  revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
+  version = "v1.0.2"
 
 [[projects]]
-  name = "github.com/openzipkin/zipkin-go-opentracing"
-  packages = [
-    ".",
-    "_thrift/gen-go/scribe",
-    "_thrift/gen-go/zipkincore",
-    "flag",
-    "types",
-    "wire"
-  ]
-  revision = "6022d4d3ed39632fad842942bda1813a9b4f63c8"
-  version = "v0.2.3"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/pierrec/lz4"
+  name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "f5b77fd73d83122495309c0f459b810f83cc291f"
-
-[[projects]]
-  name = "github.com/pierrec/xxHash"
-  packages = ["xxHash32"]
-  revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
-  version = "v0.1.1"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -215,13 +137,13 @@
   branch = "master"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
-  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
+  revision = "82f5ff156b29e276022b1a958f7d385870fb9814"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
@@ -231,28 +153,24 @@
     "internal/bitbucket.org/ww/goautoneg",
     "model"
   ]
-  revision = "9e0844febd9e2856f839c9cb974fbd676d1755a8"
+  revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
+    "internal/util",
+    "nfs",
     "xfs"
   ]
-  revision = "6ac8c5d890d415025dd5aae7595bcb2a6e7e2fad"
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/rcrowley/go-metrics"
-  packages = ["."]
-  revision = "1f30fe9094a513ce4c700b9a54458bbb0c96996c"
-
-[[projects]]
-  branch = "master"
   name = "github.com/sercand/kuberesolver"
   packages = ["."]
-  revision = "2f561e34ecb6206fcad82f0c5842379188d8db40"
+  revision = "f0a61d5e8ca1bcc7a607d6de3dfd51467791db88"
+  version = "v2.1.0"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -260,8 +178,8 @@
     ".",
     "hooks/test"
   ]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -269,8 +187,8 @@
     "assert",
     "require"
   ]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   name = "github.com/uber/jaeger-client-go"
@@ -280,8 +198,11 @@
     "internal/baggage",
     "internal/baggage/remote",
     "internal/spanlog",
+    "internal/throttler",
+    "internal/throttler/remote",
     "log",
     "rpcmetrics",
+    "thrift",
     "thrift-gen/agent",
     "thrift-gen/baggage",
     "thrift-gen/jaeger",
@@ -289,20 +210,14 @@
     "thrift-gen/zipkincore",
     "utils"
   ]
-  revision = "0ce42f3f87dae4f5ba84bdc60c99a908db419cb8"
-  version = "v2.10.0"
+  revision = "b043381d944715b469fd6b37addfd30145ca1758"
+  version = "v2.14.0"
 
 [[projects]]
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
-  revision = "c48167d9cae5887393dd5e61efd06a4a48b7fbb3"
-  version = "v1.2.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/weaveworks-experiments/loki"
-  packages = ["pkg/client"]
-  revision = "17ff1516db3dffe25452b4cbf6e6412f303cddea"
+  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
+  version = "v1.5.0"
 
 [[projects]]
   name = "github.com/weaveworks/promrus"
@@ -314,21 +229,21 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "lex/httplex",
     "trace"
   ]
-  revision = "da118f7b8e5954f39d0d2130ab35d4bf0e3cb344"
+  revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
   branch = "master"
@@ -337,15 +252,19 @@
     "unix",
     "windows"
   ]
-  revision = "9f30dcbe5be197894515a338a9bda9253567ea8f"
+  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
     "internal/gen",
+    "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "language",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -353,44 +272,55 @@
     "unicode/norm",
     "unicode/rangetable"
   ]
-  revision = "a9a820217f98f7c8a207ec1e45a874e1fe12c478"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
   packages = ["cover"]
-  revision = "4bb9a6d30bdc727aebd0747694f31de632a5282e"
+  revision = "48418e5732e1b1e2a10207c8007a5f959e422f20"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "d80a6e20e776b0b17a324d0ba1ab50a39c8e8944"
+  revision = "7bb2a897381c9c5ab2aeb8614f758d7766af68ff"
 
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "channelz",
     "codes",
+    "connectivity",
     "credentials",
-    "grpclb/grpc_lb_v1",
+    "encoding",
+    "encoding/proto",
+    "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
     "keepalive",
     "metadata",
     "naming",
     "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
     "stats",
     "status",
     "tap",
     "transport"
   ]
-  revision = "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-  version = "v1.3.0"
+  revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
+  version = "v1.12.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39a60544e316ef3c4186984337ab7d5044ded4853a013224618d8f924a5e9249"
+  inputs-digest = "b5a69f9edbcc9c474430576d03b5a0fc186d4f60c0bf3b2aeb62887bef59939a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,6 +170,7 @@
   name = "github.com/sercand/kuberesolver"
   packages = ["."]
   revision = "aa801ca262949d887bbe0bae3f6f731ac82c26f6"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -320,6 +321,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8d0ad365d5707a10ed9448a40c405edde58a43adb9cdab773fa69bf8e9acee2e"
+  inputs-digest = "4c5d338c89a50a8734232d9f55fe96f3dcbd31f6f0387a3a1466404df4925090"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -169,8 +169,7 @@
 [[projects]]
   name = "github.com/sercand/kuberesolver"
   packages = ["."]
-  revision = "f0a61d5e8ca1bcc7a607d6de3dfd51467791db88"
-  version = "v2.1.0"
+  revision = "aa801ca262949d887bbe0bae3f6f731ac82c26f6"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -321,6 +320,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b5a69f9edbcc9c474430576d03b5a0fc186d4f60c0bf3b2aeb62887bef59939a"
+  inputs-digest = "8d0ad365d5707a10ed9448a40c405edde58a43adb9cdab773fa69bf8e9acee2e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,3 +6,7 @@
 [[constraint]]
   name = "github.com/prometheus/client_golang"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/sercand/kuberesolver"
+  revision = "aa801ca262949d887bbe0bae3f6f731ac82c26f6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,6 +7,9 @@
   name = "github.com/prometheus/client_golang"
   branch = "master"
 
+# After aa801ca (v1.0.0), kuberesolver changed its API in a non-backwards
+# compatible way. We need to pin this old version until we can refactor to the
+# new API.
 [[constraint]]
   name = "github.com/sercand/kuberesolver"
-  revision = "aa801ca262949d887bbe0bae3f6f731ac82c26f6"
+  version = "1.0.0"

--- a/circle.yml
+++ b/circle.yml
@@ -2,14 +2,14 @@ machine:
   services:
     - docker
   environment:
-    REPO_ROOT: ${HOME}/.go_workspace/src/github.com/${CIRCLE_PROJECT_USERNAME}
+    REPO_ROOT: ${HOME}/.go_workspace/src/github.com/weaveworks/common
 
 dependencies:
   cache_directories:
     - "~/docker"
   post:
     # Get the dependencies
-    - mkdir -p ${REPO_ROOT} && cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME} ${REPO_ROOT}
+    - mkdir -p ${HOME}/.go_workspace/src/github.com/weaveworks && cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME}/ ${REPO_ROOT}
 
     # Don't use master dep until https://github.com/weaveworks/common/pull/36 is fixed
     #- go get -u github.com/golang/dep/cmd/dep && cd ${REPO_ROOT}/${CIRCLE_PROJECT_REPONAME} && dep ensure -v
@@ -18,15 +18,15 @@ dependencies:
         curl -fsSLo dep 'https://drive.google.com/uc?export=download&id=0BwqTw528sZRIUzExY29ZMm5LVTQ' && \
         echo "f006f1e41b177e84df36116e08d23f364b7f2d7549c45221c6c7e90b2148cb7f  dep" | sha256sum -c && \
         chmod +x dep && mkdir -p ${HOME}/.go_workspace/bin/ && mv dep ${HOME}/.go_workspace/bin/ && \
-        cd ${REPO_ROOT}/${CIRCLE_PROJECT_REPONAME} && dep ensure -v
+        cd ${REPO_ROOT}/ && dep ensure -v
 
     # Cache the build image
     - |
-        cd ${REPO_ROOT}/${CIRCLE_PROJECT_REPONAME}/common-build && \
+        cd ${REPO_ROOT}/common-build && \
         ../tools/rebuild-image weaveworks/common-build . build.sh Dockerfile && \
         touch .uptodate
 
 test:
   override:
-    - cd ${REPO_ROOT}/${CIRCLE_PROJECT_REPONAME}; make RM= lint
-    - cd ${REPO_ROOT}/${CIRCLE_PROJECT_REPONAME}; make RM= test
+    - cd ${REPO_ROOT}; make RM= lint
+    - cd ${REPO_ROOT}; make RM= test

--- a/middleware/grpc_auth.go
+++ b/middleware/grpc_auth.go
@@ -17,6 +17,17 @@ func ClientUserHeaderInterceptor(ctx context.Context, method string, req, reply 
 	return invoker(ctx, method, req, reply, cc, opts...)
 }
 
+// StreamClientUserHeaderInterceptor propagates the user ID from the context to gRPC metadata, which eventually ends up as a HTTP2 header.
+// For streaming gRPC requests.
+func StreamClientUserHeaderInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx, err := user.InjectIntoGRPCRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
 // ServerUserHeaderInterceptor propagates the user ID from the gRPC metadata back to our context.
 func ServerUserHeaderInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	_, ctx, err := user.ExtractFromGRPCRequest(ctx)
@@ -25,4 +36,26 @@ func ServerUserHeaderInterceptor(ctx context.Context, req interface{}, info *grp
 	}
 
 	return handler(ctx, req)
+}
+
+// StreamServerUserHeaderInterceptor propagates the user ID from the gRPC metadata back to our context.
+func StreamServerUserHeaderInterceptor(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	_, ctx, err := user.ExtractFromGRPCRequest(ss.Context())
+	if err != nil {
+		return err
+	}
+
+	return handler(srv, serverStream{
+		ctx:          ctx,
+		ServerStream: ss,
+	})
+}
+
+type serverStream struct {
+	ctx context.Context
+	grpc.ServerStream
+}
+
+func (ss serverStream) Context() context.Context {
+	return ss.ctx
 }

--- a/middleware/grpc_instrumentation.go
+++ b/middleware/grpc_instrumentation.go
@@ -10,8 +10,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// ServerInstrumentInterceptor instruments gRPC requests for errors and latency.
-func ServerInstrumentInterceptor(hist *prometheus.HistogramVec) grpc.UnaryServerInterceptor {
+// UnaryServerInstrumentInterceptor instruments gRPC requests for errors and latency.
+func UnaryServerInstrumentInterceptor(hist *prometheus.HistogramVec) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		begin := time.Now()
 		resp, err := handler(ctx, req)
@@ -26,5 +26,24 @@ func ServerInstrumentInterceptor(hist *prometheus.HistogramVec) grpc.UnaryServer
 		}
 		hist.WithLabelValues(gRPC, info.FullMethod, respStatus, "false").Observe(duration)
 		return resp, err
+	}
+}
+
+// StreamServerInstrumentInterceptor instruments gRPC requests for errors and latency.
+func StreamServerInstrumentInterceptor(hist *prometheus.HistogramVec) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		begin := time.Now()
+		err := handler(srv, ss)
+		duration := time.Since(begin).Seconds()
+		respStatus := "success"
+		if err != nil {
+			if errResp, ok := httpgrpc.HTTPResponseFromError(err); ok {
+				respStatus = strconv.Itoa(int(errResp.Code))
+			} else {
+				respStatus = "error"
+			}
+		}
+		hist.WithLabelValues(gRPC, info.FullMethod, respStatus, "false").Observe(duration)
+		return err
 	}
 }

--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -33,3 +33,16 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 	}
 	return resp, err
 }
+
+// StreamServerInterceptor returns an interceptor that logs gRPC requests
+func (s GRPCServerLog) StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	begin := time.Now()
+	err := handler(srv, ss)
+	entry := logging.With(ss.Context()).WithFields(log.Fields{"method": info.FullMethod, "duration": time.Since(begin)})
+	if err != nil {
+		entry.WithError(err).Warn(gRPC)
+	} else {
+		entry.Debugf("%s (success)", gRPC)
+	}
+	return err
+}

--- a/server/server.go
+++ b/server/server.go
@@ -39,9 +39,10 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration
 	HTTPServerIdleTimeout         time.Duration
 
-	GRPCOptions    []grpc.ServerOption
-	GRPCMiddleware []grpc.UnaryServerInterceptor
-	HTTPMiddleware []middleware.Interface
+	GRPCOptions          []grpc.ServerOption
+	GRPCMiddleware       []grpc.UnaryServerInterceptor
+	GRPCStreamMiddleware []grpc.StreamServerInterceptor
+	HTTPMiddleware       []middleware.Interface
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -57,7 +58,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Server wraps a HTTP and gRPC server, and some common initialization.
 //
-// Servers will be automatically instrumented for Prometheus metrics.
+// Servers will be automatically instrumented for Prometheus metrics
+// and Loki tracing.  HTTP over gRPC
 type Server struct {
 	cfg          Config
 	handler      *signals.Handler
@@ -95,13 +97,24 @@ func New(cfg Config) (*Server, error) {
 	serverLog := middleware.GRPCServerLog{WithRequest: !cfg.ExcludeRequestInLog}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
-		middleware.ServerInstrumentInterceptor(requestDuration),
+		middleware.UnaryServerInstrumentInterceptor(requestDuration),
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
+
+	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
+		serverLog.StreamServerInterceptor,
+		middleware.StreamServerInstrumentInterceptor(requestDuration),
+		otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer()),
+	}
+	grpcStreamMiddleware = append(grpcStreamMiddleware, cfg.GRPCStreamMiddleware...)
+
 	grpcOptions := []grpc.ServerOption{
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpcMiddleware...,
+		)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
+			grpcStreamMiddleware...,
 		)),
 	}
 	grpcOptions = append(grpcOptions, cfg.GRPCOptions...)

--- a/server/server.go
+++ b/server/server.go
@@ -58,8 +58,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // Server wraps a HTTP and gRPC server, and some common initialization.
 //
-// Servers will be automatically instrumented for Prometheus metrics
-// and Loki tracing.  HTTP over gRPC
+// Servers will be automatically instrumented for Prometheus metrics.
 type Server struct {
 	cfg          Config
 	handler      *signals.Handler


### PR DESCRIPTION
Adds a series of gRPC _stream_ middleware for logging, user header propagation and tracing.  This is laying groundwork for using gRPC streaming between ingesters and queriers in Cortex.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>