### PR TITLE
Don't shutdown the gRPC server the minute a signal is received.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -168,7 +168,6 @@ func (s *Server) Run() {
 	// for HTTP over gRPC, ensure we don't double-count the middleware
 	httpgrpc.RegisterHTTPServer(s.GRPC, httpgrpc_server.NewServer(s.HTTP))
 	go s.GRPC.Serve(s.grpcListener)
-	defer s.GRPC.GracefulStop()
 
 	// Wait for a signal
 	s.handler.Loop()
@@ -185,5 +184,5 @@ func (s *Server) Shutdown() {
 	defer cancel() // releases resources if httpServer.Shutdown completes before timeout elapses
 
 	s.httpServer.Shutdown(ctx)
-	s.GRPC.Stop()
+	s.GRPC.GracefulStop()
 }


### PR DESCRIPTION
gRPC behaviour should be the same as HTTP: `Run()` exits when a signal is received, and `Stop()` stops the handling of requests.

See https://github.com/weaveworks/cortex/issues/882

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>