### PR TITLE
Default diff-printer to hide details

### DIFF
--- a/test/diff.go
+++ b/test/diff.go
@@ -8,7 +8,9 @@ import (
 // Diff diffs two arbitrary data structures, giving human-readable output.
 func Diff(want, have interface{}) string {
 	config := spew.NewDefaultConfig()
-	config.ContinueOnMethod = true
+	// Set ContinueOnMethod to true if you cannot see a difference and
+	// want to look beyond the String() method
+	config.ContinueOnMethod = false
 	config.SortKeys = true
 	config.SpewKeys = true
 	text, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{


### PR DESCRIPTION
Fixes #80.  Finally got sick of overriding it locally.

This new setting will make it print the difference between `String()` output only.  This is more usable for developers in 99% of cases where the difference can be seen.