### PR TITLE
Set $SRC_PATH as required by the build container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ lint test shell:
 	$(SUDO) docker run $(RM) -ti \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/go/src/github.com/weaveworks/common \
+		-e SRC_PATH=/go/src/github.com/weaveworks/common \
 		$(BUILD_IMAGE) $@
 
 else


### PR DESCRIPTION
This was missed in the earlier change (#98) to use the image from build-tools.