### PR TITLE
Expose the HTTP server from the server struct.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -66,9 +66,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 type Server struct {
 	cfg          Config
 	handler      *signals.Handler
-	httpListener net.Listener
 	grpcListener net.Listener
-	httpServer   *http.Server
+	httpListener net.Listener
 
 	HTTP       *mux.Router
 	HTTPServer *http.Server
@@ -164,7 +163,6 @@ func New(cfg Config) (*Server, error) {
 		cfg:          cfg,
 		httpListener: httpListener,
 		grpcListener: grpcListener,
-		httpServer:   httpServer,
 		handler:      signals.NewHandler(log),
 
 		HTTP:       router,
@@ -194,7 +192,7 @@ func (s *Server) Run() error {
 	}()
 
 	go func() {
-		err := s.httpServer.Serve(s.httpListener)
+		err := s.HTTPServer.Serve(s.httpListener)
 		if err == http.ErrServerClosed {
 			err = nil
 		}
@@ -234,6 +232,6 @@ func (s *Server) Shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), s.cfg.ServerGracefulShutdownTimeout)
 	defer cancel() // releases resources if httpServer.Shutdown completes before timeout elapses
 
-	s.httpServer.Shutdown(ctx)
+	s.HTTPServer.Shutdown(ctx)
 	s.GRPC.GracefulStop()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -180,7 +180,7 @@ func RegisterInstrumentation(router *mux.Router) {
 
 // Run the server; blocks until SIGTERM or an error is received.
 func (s *Server) Run() error {
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	// Wait for a signal
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -70,9 +70,10 @@ type Server struct {
 	grpcListener net.Listener
 	httpServer   *http.Server
 
-	HTTP *mux.Router
-	GRPC *grpc.Server
-	Log  logging.Interface
+	HTTP       *mux.Router
+	HTTPServer *http.Server
+	GRPC       *grpc.Server
+	Log        logging.Interface
 }
 
 // New makes a new Server
@@ -166,9 +167,10 @@ func New(cfg Config) (*Server, error) {
 		httpServer:   httpServer,
 		handler:      signals.NewHandler(log),
 
-		HTTP: router,
-		GRPC: grpcServer,
-		Log:  log,
+		HTTP:       router,
+		HTTPServer: httpServer,
+		GRPC:       grpcServer,
+		Log:        log,
 	}, nil
 }
 


### PR DESCRIPTION
This allows users to inject HTTP requests and have the logged, instrumented and traced correctly.

See https://github.com/weaveworks/cortex/issues/949

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>