### PR TITLE
Add HTTP tracing middleware

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
+	"github.com/opentracing/opentracing-go"
+)
+
+// Tracer is a middleware which traces incoming requests.
+type Tracer struct{}
+
+// Wrap implements Interface
+func (t Tracer) Wrap(next http.Handler) http.Handler {
+	traceHandler := nethttp.Middleware(opentracing.GlobalTracer(), next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var maybeTracer http.Handler
+		// Don't try and trace websocket requests because nethttp.Middleware
+		// doesn't support http.Hijack yet
+		if IsWSHandshakeRequest(r) {
+			maybeTracer = next
+		} else {
+			maybeTracer = traceHandler
+		}
+		maybeTracer.ServeHTTP(w, r)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/mwitkow/go-grpc-middleware"
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
@@ -147,9 +146,7 @@ func New(cfg Config) (*Server, error) {
 			Duration:     requestDuration,
 			RouteMatcher: router,
 		},
-		middleware.Func(func(handler http.Handler) http.Handler {
-			return nethttp.Middleware(opentracing.GlobalTracer(), handler)
-		}),
+		middleware.Tracer{},
 	}
 	httpMiddleware = append(httpMiddleware, cfg.HTTPMiddleware...)
 	httpServer := &http.Server{


### PR DESCRIPTION
Pulls https://github.com/weaveworks/scope/pull/3325 into common, and factors out server initialisation code