### PR TITLE
Print logrus output in logfmt format

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -66,6 +66,12 @@
   version = "v1.7.0"
 
 [[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -242,9 +248,12 @@
 
 [[projects]]
   name = "github.com/uber/jaeger-lib"
-  packages = ["metrics"]
-  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
-  version = "v1.5.0"
+  packages = [
+    "metrics",
+    "metrics/prometheus"
+  ]
+  revision = "5519f3beabf28707fca8d3f47f9cff87dad48d96"
+  version = "v1.3.0"
 
 [[projects]]
   name = "github.com/weaveworks/promrus"
@@ -349,6 +358,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "00ca48db1cbceb304f25a236a30e738a854dc916c58f79e8bfabb01587f6c4e5"
+  inputs-digest = "3c23de9e439a674c3438f33a4fc43538cbddef8ba80e128431726f8a39f987ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -22,7 +22,6 @@ func Setup(logLevel string) error {
 	}
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(level)
-	logrus.SetFormatter(&textFormatter{})
 	logrus.AddHook(hook)
 	SetGlobal(Logrus(logrus.StandardLogger()))
 	return nil

--- a/logging/logrus.go
+++ b/logging/logrus.go
@@ -1,10 +1,7 @@
 package logging
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -14,7 +11,6 @@ func NewLogrus(level Level) Interface {
 	log := logrus.New()
 	log.Out = os.Stderr
 	log.Level = level.Logrus
-	log.Formatter = &textFormatter{}
 	return logrusLogger{log}
 }
 
@@ -53,22 +49,4 @@ func (l logrusEntry) WithFields(fields Fields) Interface {
 	return logrusEntry{
 		Entry: l.Entry.WithFields(map[string]interface{}(fields)),
 	}
-}
-
-type textFormatter struct{}
-
-// Based off logrus.TextFormatter, which behaves completely
-// differently when you don't want colored output
-func (f *textFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	b := &bytes.Buffer{}
-
-	levelText := strings.ToUpper(entry.Level.String())[0:4]
-	timeStamp := entry.Time.Format("2006/01/02 15:04:05.000000")
-	fmt.Fprintf(b, "%s: %s %s", levelText, timeStamp, entry.Message)
-	if len(entry.Data) > 0 {
-		b.WriteString(" " + fieldsToString(entry.Data))
-	}
-
-	b.WriteByte('\n')
-	return b.Bytes(), nil
 }


### PR DESCRIPTION
This changes the way logrous outputs log messages in case there is no
TTY attached.

Changes from

        ERRO: 2018/08/23 20:28:10.075952 Sample log message extra=foo

to

        time="2018-08-23T20:28:10Z" level=info msg="Sample log message" extra="foo"

which follows the `logfmt` key-value format by also providing `time`,
`level`, and `msg` in adition to the extra fields.

The PR removes the custom `textFormatter` to have the default
`logrus.TextFormatter` in place which takes care of detecting whether a
terminal is attached or not and switches between text and logfmt output
automatically.
It appears the custom formatter was to prevent differences in rendering
depending on color/non-color output which I don't necessarily see as an
issue.