### PR TITLE
 Also set global logging when initializing logrus

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -4,23 +4,24 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+
 	"github.com/weaveworks/promrus"
 )
 
-// Setup configures logging output to stderr, sets the log level and sets the formatter.
+// Setup configures a global logrus logger to output to stderr.
 func Setup(logLevel string) error {
-	log.SetOutput(os.Stderr)
-	level, err := log.ParseLevel(logLevel)
+	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
-		return fmt.Errorf("Error parsing log level: %v", err)
+		return fmt.Errorf("error parsing log level: %v", err)
 	}
-	log.SetLevel(level)
-	log.SetFormatter(&textFormatter{})
 	hook, err := promrus.NewPrometheusHook() // Expose number of log messages as Prometheus metrics.
 	if err != nil {
 		return err
 	}
-	log.AddHook(hook)
+	logrus.SetOutput(os.Stderr)
+	logrus.SetLevel(level)
+	logrus.SetFormatter(&textFormatter{})
+	logrus.AddHook(hook)
 	return nil
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Setup configures a global logrus logger to output to stderr.
+// It populates the standard logrus logger as well as the global logging instance.
 func Setup(logLevel string) error {
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
@@ -23,5 +24,6 @@ func Setup(logLevel string) error {
 	logrus.SetLevel(level)
 	logrus.SetFormatter(&textFormatter{})
 	logrus.AddHook(hook)
+	SetGlobal(Logrus(logrus.StandardLogger()))
 	return nil
 }

--- a/logging/logrus.go
+++ b/logging/logrus.go
@@ -28,29 +28,29 @@ type logrusLogger struct {
 }
 
 func (l logrusLogger) WithField(key string, value interface{}) Interface {
-	return logusEntry{
+	return logrusEntry{
 		Entry: l.Logger.WithField(key, value),
 	}
 }
 
 func (l logrusLogger) WithFields(fields Fields) Interface {
-	return logusEntry{
+	return logrusEntry{
 		Entry: l.Logger.WithFields(map[string]interface{}(fields)),
 	}
 }
 
-type logusEntry struct {
+type logrusEntry struct {
 	*logrus.Entry
 }
 
-func (l logusEntry) WithField(key string, value interface{}) Interface {
-	return logusEntry{
+func (l logrusEntry) WithField(key string, value interface{}) Interface {
+	return logrusEntry{
 		Entry: l.Entry.WithField(key, value),
 	}
 }
 
-func (l logusEntry) WithFields(fields Fields) Interface {
-	return logusEntry{
+func (l logrusEntry) WithFields(fields Fields) Interface {
+	return logrusEntry{
 		Entry: l.Entry.WithFields(map[string]interface{}(fields)),
 	}
 }


### PR DESCRIPTION
This PR sets the global logging instance when calling `logging.Setup(level)`.
Previously, only the standard logrus logger was set up and if anyone used
the new funcs such as `logging.Info()` it was discarded.