### PR TITLE
Print traceID with request

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
+	"golang.org/x/net/context"
 )
 
 // Tracer is a middleware which traces incoming requests.
@@ -24,4 +26,18 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 		}
 		maybeTracer.ServeHTTP(w, r)
 	})
+}
+
+// ExtractTraceID extracts the trace id, if any from the context.
+func ExtractTraceID(ctx context.Context) (string, bool) {
+	sp := opentracing.SpanFromContext(ctx)
+	if sp == nil {
+		return "", false
+	}
+	sctx, ok := sp.Context().(jaeger.SpanContext)
+	if !ok {
+		return "", false
+	}
+
+	return sctx.TraceID().String(), true
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -17,6 +17,11 @@ type Log struct {
 
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) logging.Interface {
+	traceID, ok := ExtractTraceID(r.Context())
+	if ok {
+		l.Log = l.Log.WithField("traceID", traceID)
+	}
+
 	return user.LogWith(r.Context(), l.Log)
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -139,6 +139,7 @@ func New(cfg Config) (*Server, error) {
 		RegisterInstrumentation(router)
 	}
 	httpMiddleware := []middleware.Interface{
+		middleware.Tracer{},
 		middleware.Log{
 			Log: log,
 		},
@@ -146,8 +147,8 @@ func New(cfg Config) (*Server, error) {
 			Duration:     requestDuration,
 			RouteMatcher: router,
 		},
-		middleware.Tracer{},
 	}
+
 	httpMiddleware = append(httpMiddleware, cfg.HTTPMiddleware...)
 	httpServer := &http.Server{
 		ReadTimeout:  cfg.HTTPServerReadTimeout,


### PR DESCRIPTION
```
level=debug ts=2018-08-28T15:57:09.13499093Z caller=gokit.go:29 traceID=75e33027dba459a3 msg="GET /api/prom/api/v1/query?query=prometheus_test_exporter_now_seconds%7Bjob%3D%22dev%2Ftest-exporter%22%7D%5B59m%5D&time=2018-08-21T02%3A03%3A08.019055392Z (200) 67.490589ms"
```

This'll help with debugging query latencies and other things quite easy. 