### PR TITLE
Fix dropped namespace in url parsing

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -91,13 +91,17 @@ func ParseURL(unparsed string) (string, []grpc.DialOption, error) {
 		if err != nil {
 			return "", nil, err
 		}
-		parts := strings.SplitN(host, ".", 2)
-		service, namespace := parts[0], "default"
-		if len(parts) == 2 {
+		parts := strings.SplitN(host, ".", 3)
+		service, namespace, domain := parts[0], "default", ""
+		if len(parts) > 1 {
 			namespace = parts[1]
+			domain = "." + namespace
+		}
+		if len(parts) > 2 {
+			domain = domain + "." + parts[2]
 		}
 		balancer := kuberesolver.NewWithNamespace(namespace)
-		address := fmt.Sprintf("kubernetes://%s:%s", service, port)
+		address := fmt.Sprintf("kubernetes://%s%s:%s", service, domain, port)
 		dialOptions := []grpc.DialOption{balancer.DialOption()}
 		return address, dialOptions, nil
 

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -96,7 +96,8 @@ func TestParseURL(t *testing.T) {
 	}{
 		{"direct://foo", "foo", nil},
 		{"kubernetes://foo:123", "kubernetes://foo:123", nil},
-		{"querier.cortex:995", "kubernetes://querier:995", nil},
+		{"querier.cortex:995", "kubernetes://querier.cortex:995", nil},
+		{"foo.bar.svc.local:995", "kubernetes://foo.bar.svc.local:995", nil},
 	} {
 		got, _, err := ParseURL(tc.input)
 		if !reflect.DeepEqual(tc.err, err) {


### PR DESCRIPTION
Causes problems if you try and connect from one namespace to another.