### PR TITLE
Allow server.Config to be unmarshaled from YAML.

### DIFF
--- a/logging/level.go
+++ b/logging/level.go
@@ -40,7 +40,16 @@ func (l *Level) String() string {
 	return l.s
 }
 
-// Set updates the value of the allowed level.
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var level string
+	if err := unmarshal(&level); err != nil {
+		return err
+	}
+	return l.Set(level)
+}
+
+// Set updates the value of the allowed level.  Implments flag.Value.
 func (l *Level) Set(s string) error {
 	switch s {
 	case "debug":

--- a/server/server.go
+++ b/server/server.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,27 +26,27 @@ import (
 
 // Config for a Server
 type Config struct {
-	MetricsNamespace string
-	HTTPListenPort   int
-	GRPCListenPort   int
+	MetricsNamespace string `yaml:"-"`
+	HTTPListenPort   int    `yaml:"http_listen_port"`
+	GRPCListenPort   int    `yaml:"grpc_listen_port"`
 
-	RegisterInstrumentation bool
-	ExcludeRequestInLog     bool
+	RegisterInstrumentation bool `yaml:"-"`
+	ExcludeRequestInLog     bool `yaml:"-"`
 
-	ServerGracefulShutdownTimeout time.Duration
-	HTTPServerReadTimeout         time.Duration
-	HTTPServerWriteTimeout        time.Duration
-	HTTPServerIdleTimeout         time.Duration
+	ServerGracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
+	HTTPServerReadTimeout         time.Duration `yaml:"http_server_read_timeout"`
+	HTTPServerWriteTimeout        time.Duration `yaml:"http_server_write_timeout"`
+	HTTPServerIdleTimeout         time.Duration `yaml:"http_server_idle_timeout"`
 
-	GRPCOptions          []grpc.ServerOption
-	GRPCMiddleware       []grpc.UnaryServerInterceptor
-	GRPCStreamMiddleware []grpc.StreamServerInterceptor
-	HTTPMiddleware       []middleware.Interface
+	GRPCOptions          []grpc.ServerOption            `yaml:"-"`
+	GRPCMiddleware       []grpc.UnaryServerInterceptor  `yaml:"-"`
+	GRPCStreamMiddleware []grpc.StreamServerInterceptor `yaml:"-"`
+	HTTPMiddleware       []middleware.Interface         `yaml:"-"`
 
-	LogLevel logging.Level
-	Log      logging.Interface
+	LogLevel logging.Level     `yaml:"log_level"`
+	Log      logging.Interface `yaml:"-"`
 
-	PathPrefix string
+	PathPrefix string `yaml:"http_path_prefix"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet


### PR DESCRIPTION
This is so we can load flags from a YAML file in Cortex.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>