### PR TITLE
Log which ports the server is listening on.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -103,6 +103,8 @@ func New(cfg Config) (*Server, error) {
 		log = logging.NewLogrus(cfg.LogLevel)
 	}
 
+	log.WithField("http", httpListener.Addr()).WithField("grpc", grpcListener.Addr()).Infof("server listening on addresses")
+
 	// Setup gRPC server
 	serverLog := middleware.GRPCServerLog{
 		WithRequest: !cfg.ExcludeRequestInLog,


### PR DESCRIPTION
Motivation here is making Cortex "single-binary" easier to use.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>