### PR TITLE
Allow overriding max message sizes and concurrent streams in the gRPC server.

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"flag"
 	"net/http"
 	"strconv"
 	"testing"
@@ -33,7 +34,9 @@ func (f FakeServer) Succeed(ctx context.Context, req *google_protobuf.Empty) (*g
 }
 
 func TestErrorInstrumentationMiddleware(t *testing.T) {
-	cfg := Config{GRPCListenPort: 1234}
+	var cfg Config
+	cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
+	cfg.GRPCListenPort = 1234
 	server, err := New(cfg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
NB This use the gRPC defaults as the flag defaults.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>