### PR TITLE
Dont flag context.Canceled as an error in tracing

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -152,7 +152,9 @@ func CollectedRequest(ctx context.Context, method string, col Collector, toStatu
 	col.After(method, toStatusCode(err), start)
 
 	if err != nil {
-		ext.Error.Set(sp, true)
+		if err != context.Canceled {
+			ext.Error.Set(sp, true)
+		}
 		sp.LogFields(otlog.Error(err))
 	}
 	sp.Finish()


### PR DESCRIPTION
Cancellations are always caused by something else, so having them show up as errors in the tracing UI is distracting.