### PR TITLE
server: use -server.path-prefix for metrics and debug endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -150,11 +150,13 @@ func New(cfg Config) (*Server, error) {
 
 	// Setup HTTP server
 	router := mux.NewRouter()
+	if cfg.PathPrefix != "" {
+		// Expect metrics and pprof handlers to be prefixed with server's path prefix.
+		// e.g. /loki/metrics or /loki/debug/pprof
+		router = router.PathPrefix(cfg.PathPrefix).Subrouter()
+	}
 	if cfg.RegisterInstrumentation {
 		RegisterInstrumentation(router)
-	}
-	if cfg.PathPrefix != "" {
-		router = router.PathPrefix(cfg.PathPrefix).Subrouter()
 	}
 	httpMiddleware := []middleware.Interface{
 		middleware.Tracer{


### PR DESCRIPTION
Previously calling `Subrouter()` would overwrite the instrumentation handlers and they'd be ignored when PathPrefix was specified. This meant one could never get back metrics or debug endpoints.

I verified metrics and api endpoints respond with this change locally, but writing a test didn't work as creating a new `Server` (via `New(..)`) mutates global state and prometheus panics on duplicate metric registrations. We could pass in a prometheus registry, but that breaks the public constructor. 

```go
func TestInstrumentationPathPrefix(t *testing.T) {
	var cfg Config
	cfg.PathPrefix = "/loki/"
	cfg.HTTPListenPort = 10101
	cfg.RegisterInstrumentation = true
	server, err := New(cfg)
	require.NoError(t, err)

	go server.Run()
	defer server.Shutdown()

	resp, err := http.DefaultClient.Get("http://localhost:10101/loki/metrics")
	if resp != nil && resp.Body != nil {
		resp.Body.Close()
	}
	require.NoError(t, err)
	if resp.StatusCode != http.StatusOK {
		t.Errorf("bogus HTTP status: %v", resp.Status)
	}
}
```

Related: https://github.com/weaveworks/common/pull/144 
