### PR TITLE
Allow log levels to be marshalled to YAML.  Test it works.

### DIFF
--- a/logging/level.go
+++ b/logging/level.go
@@ -49,6 +49,11 @@ func (l *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return l.Set(level)
 }
 
+// MarshalYAML implements yaml.Marshaler.
+func (l Level) MarshalYAML() (interface{}, error) {
+	return l.String(), nil
+}
+
 // Set updates the value of the allowed level.  Implments flag.Value.
 func (l *Level) Set(s string) error {
 	switch s {

--- a/logging/level_test.go
+++ b/logging/level_test.go
@@ -1,0 +1,24 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestMarshalYAML(t *testing.T) {
+	var l Level
+	err := l.Set("debug")
+	require.NoError(t, err)
+
+	// Test the non-pointed to Level, as people might embed it.
+	y, err := yaml.Marshal(l)
+	require.NoError(t, err)
+	require.Equal(t, []byte("debug\n"), y)
+
+	// And the pointed to Level.
+	y, err = yaml.Marshal(&l)
+	require.NoError(t, err)
+	require.Equal(t, []byte("debug\n"), y)
+}


### PR DESCRIPTION
Needed to Cortex can print its own config.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>