### PR TITLE
Allow user to specify HTTP and gRPC bind addresses (not just ports.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: quay.io/weaveworks/build-golang:1.10.0-stretch
+    - image: weaveworks/build-golang:1.10.0-stretch
   working_directory: /go/src/github.com/weaveworks/common
 
 workflows:

--- a/server/server.go
+++ b/server/server.go
@@ -27,7 +27,9 @@ import (
 // Config for a Server
 type Config struct {
 	MetricsNamespace string `yaml:"-"`
+	HTTPListenHost   string `yaml:"http_listen_host"`
 	HTTPListenPort   int    `yaml:"http_listen_port"`
+	GRPCListenHost   string `yaml:"grpc_listen_host"`
 	GRPCListenPort   int    `yaml:"grpc_listen_port"`
 
 	RegisterInstrumentation bool `yaml:"-"`
@@ -55,7 +57,9 @@ type Config struct {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	f.StringVar(&cfg.HTTPListenHost, "server.http-listen-host", "", "HTTP server listen host.")
 	f.IntVar(&cfg.HTTPListenPort, "server.http-listen-port", 80, "HTTP server listen port.")
+	f.StringVar(&cfg.GRPCListenHost, "server.grpc-listen-host", "", "gRPC server listen host.")
 	f.IntVar(&cfg.GRPCListenPort, "server.grpc-listen-port", 9095, "gRPC server listen port.")
 	f.BoolVar(&cfg.RegisterInstrumentation, "server.register-instrumentation", true, "Register the intrumentation handlers (/metrics etc).")
 	f.DurationVar(&cfg.ServerGracefulShutdownTimeout, "server.graceful-shutdown-timeout", 30*time.Second, "Timeout for graceful shutdowns")
@@ -87,12 +91,12 @@ type Server struct {
 // New makes a new Server
 func New(cfg Config) (*Server, error) {
 	// Setup listeners first, so we can fail early if the port is in use.
-	httpListener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.HTTPListenPort))
+	httpListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.HTTPListenHost, cfg.HTTPListenPort))
 	if err != nil {
 		return nil, err
 	}
 
-	grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCListenPort))
+	grpcListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.GRPCListenHost, cfg.GRPCListenPort))
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,6 +36,9 @@ func (f FakeServer) Succeed(ctx context.Context, req *google_protobuf.Empty) (*g
 func TestErrorInstrumentationMiddleware(t *testing.T) {
 	var cfg Config
 	cfg.RegisterFlags(flag.NewFlagSet("", flag.ExitOnError))
+	cfg.HTTPListenHost = "localhost"
+	cfg.HTTPListenPort = 9190
+	cfg.GRPCListenHost = "localhost"
 	cfg.GRPCListenPort = 1234
 	server, err := New(cfg)
 	require.NoError(t, err)
@@ -102,7 +105,9 @@ func TestErrorInstrumentationMiddleware(t *testing.T) {
 
 func TestRunReturnsError(t *testing.T) {
 	cfg := Config{
+		HTTPListenHost: "localhost",
 		HTTPListenPort: 9190,
+		GRPCListenHost: "localhost",
 		GRPCListenPort: 9191,
 	}
 	t.Run("http", func(t *testing.T) {
@@ -142,7 +147,9 @@ func TestMiddlewareLogging(t *testing.T) {
 	var level logging.Level
 	level.Set("info")
 	cfg := Config{
+		HTTPListenHost:   "localhost",
 		HTTPListenPort:   9192,
+		GRPCListenHost:   "localhost",
 		HTTPMiddleware:   []middleware.Interface{middleware.Logging},
 		MetricsNamespace: "testing_logging",
 		LogLevel:         level,


### PR DESCRIPTION
This allows us to use 'localhost' in tests, and prevents an 'Allow connections from...' dialog on MacOS when running unit tests.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>