### PR TITLE
use https if provided as scheme

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -45,6 +45,9 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 	}
 
 	if strings.Contains(awsURL.Host, ".") {
+		if awsURL.Scheme == "https" {
+			return config.WithEndpoint(fmt.Sprintf("https://%s", awsURL.Host)).WithRegion("dummy"), nil
+		}
 		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion("dummy"), nil
 	}
 


### PR DESCRIPTION
If the scheme was set to https, respect https otherwise default to http as always.