### PR TITLE
Allow region to be read from environment variable

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -45,10 +46,14 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 	}
 
 	if strings.Contains(awsURL.Host, ".") {
-		if awsURL.Scheme == "https" {
-			return config.WithEndpoint(fmt.Sprintf("https://%s", awsURL.Host)).WithRegion("dummy"), nil
+		region := os.Getenv("AWS_REGION")
+		if region == "" {
+			region = "dummy"
 		}
-		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion("dummy"), nil
+		if awsURL.Scheme == "https" {
+			return config.WithEndpoint(fmt.Sprintf("https://%s", awsURL.Host)).WithRegion(region), nil
+		}
+		return config.WithEndpoint(fmt.Sprintf("http://%s", awsURL.Host)).WithRegion(region), nil
 	}
 
 	// Let AWS generate default endpoint based on region passed as a host in URL.


### PR DESCRIPTION
Allow region to be read from environment variable.

For using custom s3 endpoint, some providers expects valid endpoint with valid `region`. This change should allow to use region from environment variable. If not defined it will fallback to `dummy`

Fixes #165 