### PR TITLE
Tell Go runtime we have stopped listening to signals

### DIFF
--- a/signals/signals.go
+++ b/signals/signals.go
@@ -42,6 +42,7 @@ func (h *Handler) Stop() {
 func (h *Handler) Loop() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	defer signal.Stop(sigs)
 	buf := make([]byte, 1<<20)
 	for {
 		select {


### PR DESCRIPTION
If we exit the handler loop, e.g. after receiving SIGTERM, then we don't want Go to attempt further delivery of signals.