### PR TITLE
add flags to configure keep alive configs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,7 @@ package server
 import (
 	"flag"
 	"fmt"
-	math "math"
+	"math"
 	"net"
 	"net/http"
 	_ "net/http/pprof" // anonymous import to get the pprof handler registered

--- a/server/server.go
+++ b/server/server.go
@@ -51,11 +51,11 @@ type Config struct {
 	GPRCServerMaxRecvMsgSize        int           `yaml:"grpc_server_max_recv_msg_size"`
 	GRPCServerMaxSendMsgSize        int           `yaml:"grpc_server_max_send_msg_size"`
 	GPRCServerMaxConcurrentStreams  uint          `yaml:"grpc_server_max_concurrent_streams"`
-	GRPCServerMaxConnectionIdle     time.Duration `yaml:"grpc_max_connection_idle"`
-	GRPCServerMaxConnectionAge      time.Duration `yaml:"grpc_max_connection_age"`
-	GRPCServerMaxConnectionAgeGrace time.Duration `yaml:"grpc_max_connection_age_grace"`
-	GRPCServerTime                  time.Duration `yaml:"grpc_keepalive_time"`
-	GRPCServerTimeout               time.Duration `yaml:"grpc_keepalive_timeout"`
+	GRPCServerMaxConnectionIdle     time.Duration `yaml:"grpc_server_max_connection_idle"`
+	GRPCServerMaxConnectionAge      time.Duration `yaml:"grpc_server_max_connection_age"`
+	GRPCServerMaxConnectionAgeGrace time.Duration `yaml:"grpc_server_max_connection_age_grace"`
+	GRPCServerTime                  time.Duration `yaml:"grpc_server_keepalive_time"`
+	GRPCServerTimeout               time.Duration `yaml:"grpc_server_keepalive_timeout"`
 
 	LogLevel logging.Level     `yaml:"log_level"`
 	Log      logging.Interface `yaml:"-"`

--- a/server/server.go
+++ b/server/server.go
@@ -83,7 +83,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.DurationVar(&cfg.GRPCServerMaxConnectionAge, "server.grpc.keepalive.max-connection-age", infinty, "The duration for the maximum amount of time a connection may exist before it will be closed. Default: infinity")
 	flag.DurationVar(&cfg.GRPCServerMaxConnectionAgeGrace, "server.grpc.keepalive.max-connection-age-grace", infinty, "An additive period after max-connection-age after which the connection will be forcibly closed. Default: infinity")
 	flag.DurationVar(&cfg.GRPCServerTime, "server.grpc.keepalive.time", time.Hour*2, "Duration after which a keepalive probe is sent in case of no activity over the connection., Default: 2h")
-	flag.DurationVar(&cfg.GRPCServerTimeout, "server.grpc.keepalive.timeout", time.Second*20, "Duration after which an idle connection should be closed, Default: 20s")
+	flag.DurationVar(&cfg.GRPCServerTimeout, "server.grpc.keepalive.timeout", time.Second*20, "After having pinged for keepalive check, the duration after which an idle connection should be closed, Default: 20s")
 	f.StringVar(&cfg.PathPrefix, "server.path-prefix", "", "Base path to serve all API routes from (e.g. /v1/)")
 	cfg.LogLevel.RegisterFlags(f)
 }


### PR DESCRIPTION
We are running into issues with with load balancing the distributors in cortex. We are using DNS resolution with the httpgrpc client. However, the default resolution frequency of the client is 30 minutes. Since we don't want to roll a custom resolver, the other recommended approach is to set the `max_connection_age` of the grpc server (https://github.com/grpc/grpc/issues/12295).

This PR entails the following:
* Flags to set the GRPC Server Keepalive configs that will be passed as options upon creation
* Flags default to the default values of the `grpc-go` package
* Because we don't roll the config struct itself, there are no `yaml` tags, so it won't be able to be read from a config file


Signed-off-by: Jacob Lisi <jacob.t.lisi@gmail.com>