### PR TITLE
Fix kuberesolver URLs to have three slashes

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -106,7 +106,7 @@ func ParseURL(unparsed string) (string, error) {
 		if len(parts) > 2 {
 			domain = domain + "." + parts[2]
 		}
-		address := fmt.Sprintf("kubernetes://%s%s:%s", service, domain, port)
+		address := fmt.Sprintf("kubernetes:///%s%s:%s", service, domain, port)
 		return address, nil
 
 	default:

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -95,9 +95,10 @@ func TestParseURL(t *testing.T) {
 		err      error
 	}{
 		{"direct://foo", "foo", nil},
-		{"kubernetes://foo:123", "kubernetes://foo:123", nil},
-		{"querier.cortex:995", "kubernetes://querier.cortex:995", nil},
-		{"foo.bar.svc.local:995", "kubernetes://foo.bar.svc.local:995", nil},
+		{"kubernetes://foo:123", "kubernetes:///foo:123", nil},
+		{"querier.cortex:995", "kubernetes:///querier.cortex:995", nil},
+		{"foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", nil},
+		{"kubernetes:///foo:123", "kubernetes:///foo:123", nil},
 	} {
 		got, err := ParseURL(tc.input)
 		if !reflect.DeepEqual(tc.err, err) {

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -99,6 +99,8 @@ func TestParseURL(t *testing.T) {
 		{"querier.cortex:995", "kubernetes:///querier.cortex:995", nil},
 		{"foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", nil},
 		{"kubernetes:///foo:123", "kubernetes:///foo:123", nil},
+		{"dns:///foo.bar.svc.local:995", "dns:///foo.bar.svc.local:995", nil},
+		{"monster://foo:995", "", fmt.Errorf("unrecognised scheme: monster")},
 	} {
 		got, err := ParseURL(tc.input)
 		if !reflect.DeepEqual(tc.err, err) {


### PR DESCRIPTION
According to https://github.com/grpc/grpc-go/blob/v1.19.0/clientconn.go#L125 the URLs to pass to gRPC should have three slashes. 

Empirically this works better in my environment.