### PR TITLE
Modify the parsed URL to match new grpc reqirement

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/sercand/kuberesolver"
@@ -106,7 +106,7 @@ func ParseURL(unparsed string) (string, error) {
 		if len(parts) > 2 {
 			domain = domain + "." + parts[2]
 		}
-		address := fmt.Sprintf("kubernetes://%s%s:%s", service, domain, port)
+		address := fmt.Sprintf("kubernetes:///%s%s:%s", service, domain, port)
 		return address, nil
 
 	default:

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -95,9 +95,11 @@ func TestParseURL(t *testing.T) {
 		err      error
 	}{
 		{"direct://foo", "foo", nil},
-		{"kubernetes://foo:123", "kubernetes://foo:123", nil},
-		{"querier.cortex:995", "kubernetes://querier.cortex:995", nil},
-		{"foo.bar.svc.local:995", "kubernetes://foo.bar.svc.local:995", nil},
+		{"kubernetes://foo:123", "kubernetes:///foo:123", nil},
+		{"querier.cortex:995", "kubernetes:///querier.cortex:995", nil},
+		{"foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", nil},
+		{"dns:///foo.bar.svc.local:995", "dns:///foo.bar.svc.local:995", nil},
+		{"kubernetes:///foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", nil},
 	} {
 		got, err := ParseURL(tc.input)
 		if !reflect.DeepEqual(tc.err, err) {


### PR DESCRIPTION
The newer grpcs resolvers require :///

Sorry that I missed this when I upgraded.