### PR TITLE
BREAKING CHANGE: Return error in configuring jaeger

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,24 +1,26 @@
 package tracing
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
 
+	"github.com/pkg/errors"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
 	jaegerprom "github.com/uber/jaeger-lib/metrics/prometheus"
 )
 
+// ErrInvalidConfiguration is an error to notify client to provide valid trace report agent or config server
+var (
+	ErrBlankTraceConfiguration = errors.New("no trace report agent or config server specified")
+)
+
 // installJaeger registers Jaeger as the OpenTracing implementation.
-func installJaeger(serviceName string, cfg *jaegercfg.Configuration) io.Closer {
+func installJaeger(serviceName string, cfg *jaegercfg.Configuration) (io.Closer, error) {
 	metricsFactory := jaegerprom.New()
 	closer, err := cfg.InitGlobalTracer(serviceName, jaegercfg.Metrics(metricsFactory))
 	if err != nil {
-		fmt.Printf("Could not initialize jaeger tracer: %s\n", err.Error())
-		os.Exit(1)
+		return nil, errors.Wrap(err, "could not initialize jaeger tracer")
 	}
-	return closer
+	return closer, nil
 }
 
 // NewFromEnv is a convenience function to allow tracing configuration
@@ -27,16 +29,14 @@ func installJaeger(serviceName string, cfg *jaegercfg.Configuration) io.Closer {
 // Tracing will be enabled if one (or more) of the following environment variables is used to configure trace reporting:
 // - JAEGER_AGENT_HOST
 // - JAEGER_SAMPLER_MANAGER_HOST_PORT
-func NewFromEnv(serviceName string) io.Closer {
+func NewFromEnv(serviceName string) (io.Closer, error) {
 	cfg, err := jaegercfg.FromEnv()
 	if err != nil {
-		fmt.Printf("Could not load jaeger tracer configuration: %s\n", err.Error())
-		os.Exit(1)
+		return nil, errors.Wrap(err, "could not load jaeger tracer configuration")
 	}
 
 	if cfg.Sampler.SamplingServerURL == "" && cfg.Reporter.LocalAgentHostPort == "" {
-		fmt.Printf("Jaeger tracer disabled: No trace report agent or config server specified\n")
-		return ioutil.NopCloser(nil)
+		return nil, ErrBlankTraceConfiguration
 	}
 
 	return installJaeger(serviceName, cfg)


### PR DESCRIPTION
Fixes #181 

Also, we should add a watcher so that when jaeger is up, tracing can be initialized. Should we leave this logic to client or can we implement it here?