### PR TITLE
Limit concurrent S3 connections per host

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -33,6 +33,7 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 				}).DialContext,
 				MaxIdleConns:          100,
 				IdleConnTimeout:       90 * time.Second,
+				MaxConnsPerHost:       100,
 				MaxIdleConnsPerHost:   100,
 				TLSHandshakeTimeout:   3 * time.Second,
 				ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
This commit limits the number of concurrent connections to encourage
connection reuse. `MaxIdleConnsPerHost` was already set to workaround
https://github.com/golang/go/issues/13801 ("issue which made Go consume
all ephemeral ports").

We observed a similar issue when starting up Loki (using weaveworks
`common/aws` throught Cortex) which resulted in thousands of very small
S3 requests until memcached was seeded. This failed because of ephemeral
port exhaustion: while the application in fact would have reused
connections, it already failed as it sent all of them concurrently until
most of the requests failed.

`MaxConnsPerHost` can be used to limit the overall number of parallel
connections.

An alternative solution would be to queue requests in the application, but the golang HTTP client already has a queue. Whether a maximum of 100 parallel requests is reasonable or too small might be subject of discussion. I'm not sure if there is a relevant use case of more than 100 parallel S3 streams per instance.

In my experiments, a connection limit larger than `MaxIdleConns` resulted in few connections piling up, but in a rate the system could handle well (with other words: they went through their `TIME_WAIT` window and were removed from the connection list without the system getting close to the ephemeral connection limit).