### PR TITLE
Update node_exporter version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.4.1
-	github.com/prometheus/common v0.9.1
-	github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200417100735-fa4edd700ebc
+	github.com/prometheus/common v0.9.1 // indirect
+	github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289
 	github.com/sercand/kuberesolver v2.1.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,8 @@ github.com/prometheus/node_exporter v1.0.0-rc.0 h1:uF7fKYn09REu3z1m7U/7YG2kh9inN
 github.com/prometheus/node_exporter v1.0.0-rc.0/go.mod h1:NZ2G+XKlMg3T3Sz+gGW51PHdTO5KGjPyNFlihc2whjg=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200417100735-fa4edd700ebc h1:9csPynN5NJOGA4GFef/6VUOAzs7njUiEiWW+jYUamXo=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200417100735-fa4edd700ebc/go.mod h1:FGbBv5OPKjch+jNUJmEQpMZytIdyW0NdBtWFcfSKusc=
+github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289 h1:dTUS1vaLWq+Y6XKOTnrFpoVsQKLCbCp1OLj24TDi7oM=
+github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289/go.mod h1:FGbBv5OPKjch+jNUJmEQpMZytIdyW0NdBtWFcfSKusc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=


### PR DESCRIPTION
Updates the vendored `prometheus/node_exporter` dependency which sets min TLS version to 1.2, as 1.0 and 1.1 are considered insecure.

Signed-off-by: Annanay <annanayagarwal@gmail.com>