### PR TITLE
Added option to disable signal handling by Server.

### DIFF
--- a/server/certs/genCerts.sh
+++ b/server/certs/genCerts.sh
@@ -3,7 +3,7 @@
 certFolder=$1
 days=$2
 
-pushd $certFolder
+pushd "$certFolder" || exit
 
 # keys
 openssl genrsa -out root.key
@@ -11,13 +11,13 @@ openssl genrsa -out client.key
 openssl genrsa -out server.key
 
 # root cert
-openssl req -x509 -new -nodes -key root.key -subj "/C=US/ST=KY/O=Org/CN=root" -sha256 -days $days -out root.crt
+openssl req -x509 -new -nodes -key root.key -subj "/C=US/ST=KY/O=Org/CN=root" -sha256 -days "$days" -out root.crt
 
 # csrs
 openssl req -new -sha256 -key client.key -subj "/C=US/ST=KY/O=Org/CN=client" -out client.csr
 openssl req -new -sha256 -key server.key -subj "/C=US/ST=KY/O=Org/CN=localhost" -out server.csr
 
-openssl x509 -req -in client.csr -CA root.crt -CAkey root.key -CAcreateserial -out client.crt -days $days -sha256
-openssl x509 -req -in server.csr -CA root.crt -CAkey root.key -CAcreateserial -out server.crt -days $days -sha256
+openssl x509 -req -in client.csr -CA root.crt -CAkey root.key -CAcreateserial -out client.crt -days "$days" -sha256
+openssl x509 -req -in server.csr -CA root.crt -CAkey root.key -CAcreateserial -out server.crt -days "$days" -sha256
 
-popd
+popd || exit

--- a/server/certs/genCerts.sh
+++ b/server/certs/genCerts.sh
@@ -3,7 +3,7 @@
 certFolder=$1
 days=$2
 
-pushd "$certFolder" || exit
+pushd "$certFolder"
 
 # keys
 openssl genrsa -out root.key
@@ -20,4 +20,4 @@ openssl req -new -sha256 -key server.key -subj "/C=US/ST=KY/O=Org/CN=localhost" 
 openssl x509 -req -in client.csr -CA root.crt -CAkey root.key -CAcreateserial -out client.crt -days "$days" -sha256
 openssl x509 -req -in server.csr -CA root.crt -CAkey root.key -CAcreateserial -out server.crt -days "$days" -sha256
 
-popd || exit
+popd

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,8 @@ import (
 	"github.com/weaveworks/common/signals"
 )
 
-type SignalsHandler interface {
+// SignalHandler used by Server.
+type SignalHandler interface {
 	// Starts the signals handler. This method is blocking, and returns only after signal is received,
 	// or "Stop" is called.
 	Loop()
@@ -79,7 +80,7 @@ type Config struct {
 	Log      logging.Interface `yaml:"-"`
 
 	// If not set, default signal handler is used.
-	SignalHandler SignalsHandler `yaml:"-"`
+	SignalHandler SignalHandler `yaml:"-"`
 
 	PathPrefix string `yaml:"http_path_prefix"`
 }
@@ -124,7 +125,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 // Servers will be automatically instrumented for Prometheus metrics.
 type Server struct {
 	cfg          Config
-	handler      SignalsHandler
+	handler      SignalHandler
 	grpcListener net.Listener
 	httpListener net.Listener
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -383,7 +383,7 @@ func TestStopWithDisabledSignalHandling(t *testing.T) {
 		GRPCListenPort:    9199,
 	}
 
-	var test = func(t *testing.T, metricsNamespace string, handler SignalsHandler) {
+	var test = func(t *testing.T, metricsNamespace string, handler SignalHandler) {
 		cfg.SignalHandler = handler
 		cfg.MetricsNamespace = metricsNamespace
 		srv, err := New(cfg)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -379,9 +379,9 @@ func TestTLSServer(t *testing.T) {
 func TestStopWithDisabledSignalHandling(t *testing.T) {
 	cfg := Config{
 		HTTPListenAddress: "localhost",
-		HTTPListenPort:    9190,
+		HTTPListenPort:    9198,
 		GRPCListenAddress: "localhost",
-		GRPCListenPort:    9191,
+		GRPCListenPort:    9199,
 	}
 
 	var test = func(t *testing.T, disableSignalHandling bool) {


### PR DESCRIPTION
In Cortex, we currently have extra logic [(as explained here)](https://github.com/cortexproject/cortex/pull/2542#discussion_r417884587) to handle the fact that `server.Server` type handles SIGINT/SIGTERM signals, that should trigger shutdown of entire server.

This PR adds ability to disable signal handling by Server. This will make it possible to handle signal by Cortex `Run` method instead, and to trigger shutdown of all services (incl. `Server`) cleanly, without doing [special hacks](https://github.com/cortexproject/cortex/blob/master/pkg/cortex/modules.go#L529-L534) for "Server" service. 

Option to disable signal handling is deliberately "negative" ("disable", not "enable"), to keep existing code working as before.