### PR TITLE
Make HTTP middleware optional

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,12 +62,12 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration `yaml:"http_server_write_timeout"`
 	HTTPServerIdleTimeout         time.Duration `yaml:"http_server_idle_timeout"`
 
-	GRPCOptions                    []grpc.ServerOption            `yaml:"-"`
-	GRPCMiddleware                 []grpc.UnaryServerInterceptor  `yaml:"-"`
-	GRPCStreamMiddleware           []grpc.StreamServerInterceptor `yaml:"-"`
-	HTTPMiddleware                 []middleware.Interface         `yaml:"-"`
-	Router                         *mux.Router                    `yaml:"-"`
-	DisableGeneratedHTTPMiddleware bool                           `yaml:"-"`
+	GRPCOptions                   []grpc.ServerOption            `yaml:"-"`
+	GRPCMiddleware                []grpc.UnaryServerInterceptor  `yaml:"-"`
+	GRPCStreamMiddleware          []grpc.StreamServerInterceptor `yaml:"-"`
+	HTTPMiddleware                []middleware.Interface         `yaml:"-"`
+	Router                        *mux.Router                    `yaml:"-"`
+	DoNotAddDefaultHTTPMiddleware bool                           `yaml:"-"`
 
 	GPRCServerMaxRecvMsgSize        int           `yaml:"grpc_server_max_recv_msg_size"`
 	GRPCServerMaxSendMsgSize        int           `yaml:"grpc_server_max_send_msg_size"`
@@ -286,7 +286,7 @@ func New(cfg Config) (*Server, error) {
 		},
 	}
 	httpMiddleware := []middleware.Interface{}
-	if !cfg.DisableGeneratedHTTPMiddleware {
+	if !cfg.DoNotAddDefaultHTTPMiddleware {
 		httpMiddleware = append(httpMiddleware, defaultHTTPMiddleware...)
 	}
 	httpMiddleware = append(httpMiddleware, cfg.HTTPMiddleware...)

--- a/server/server.go
+++ b/server/server.go
@@ -286,10 +286,12 @@ func New(cfg Config) (*Server, error) {
 		},
 	}
 	httpMiddleware := []middleware.Interface{}
-	if !cfg.DoNotAddDefaultHTTPMiddleware {
-		httpMiddleware = append(httpMiddleware, defaultHTTPMiddleware...)
+	if cfg.DoNotAddDefaultHTTPMiddleware {
+		httpMiddleware = cfg.HTTPMiddleware
+	} else {
+		httpMiddleware = append(defaultHTTPMiddleware, cfg.HTTPMiddleware...)
 	}
-	httpMiddleware = append(httpMiddleware, cfg.HTTPMiddleware...)
+
 	httpServer := &http.Server{
 		ReadTimeout:  cfg.HTTPServerReadTimeout,
 		WriteTimeout: cfg.HTTPServerWriteTimeout,

--- a/server/server.go
+++ b/server/server.go
@@ -62,10 +62,12 @@ type Config struct {
 	HTTPServerWriteTimeout        time.Duration `yaml:"http_server_write_timeout"`
 	HTTPServerIdleTimeout         time.Duration `yaml:"http_server_idle_timeout"`
 
-	GRPCOptions          []grpc.ServerOption            `yaml:"-"`
-	GRPCMiddleware       []grpc.UnaryServerInterceptor  `yaml:"-"`
-	GRPCStreamMiddleware []grpc.StreamServerInterceptor `yaml:"-"`
-	HTTPMiddleware       []middleware.Interface         `yaml:"-"`
+	GRPCOptions                    []grpc.ServerOption            `yaml:"-"`
+	GRPCMiddleware                 []grpc.UnaryServerInterceptor  `yaml:"-"`
+	GRPCStreamMiddleware           []grpc.StreamServerInterceptor `yaml:"-"`
+	HTTPMiddleware                 []middleware.Interface         `yaml:"-"`
+	Router                         *mux.Router                    `yaml:"-"`
+	DisableGeneratedHTTPMiddleware bool                           `yaml:"-"`
 
 	GPRCServerMaxRecvMsgSize        int           `yaml:"grpc_server_max_recv_msg_size"`
 	GRPCServerMaxSendMsgSize        int           `yaml:"grpc_server_max_send_msg_size"`
@@ -240,7 +242,12 @@ func New(cfg Config) (*Server, error) {
 	grpcServer := grpc.NewServer(grpcOptions...)
 
 	// Setup HTTP server
-	router := mux.NewRouter()
+	var router *mux.Router
+	if cfg.Router != nil {
+		router = cfg.Router
+	} else {
+		router = mux.NewRouter()
+	}
 	if cfg.PathPrefix != "" {
 		// Expect metrics and pprof handlers to be prefixed with server's path prefix.
 		// e.g. /loki/metrics or /loki/debug/pprof
@@ -249,7 +256,7 @@ func New(cfg Config) (*Server, error) {
 	if cfg.RegisterInstrumentation {
 		RegisterInstrumentation(router)
 	}
-	httpMiddleware := []middleware.Interface{
+	defaultHTTPMiddleware := []middleware.Interface{
 		middleware.Tracer{
 			RouteMatcher: router,
 		},
@@ -261,7 +268,10 @@ func New(cfg Config) (*Server, error) {
 			RouteMatcher: router,
 		},
 	}
-
+	httpMiddleware := []middleware.Interface{}
+	if !cfg.DisableGeneratedHTTPMiddleware {
+		httpMiddleware = append(httpMiddleware, defaultHTTPMiddleware...)
+	}
 	httpMiddleware = append(httpMiddleware, cfg.HTTPMiddleware...)
 	httpServer := &http.Server{
 		ReadTimeout:  cfg.HTTPServerReadTimeout,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -273,14 +273,14 @@ func TestMiddlewareLogging(t *testing.T) {
 	var level logging.Level
 	level.Set("info")
 	cfg := Config{
-		HTTPListenAddress:              "localhost",
-		HTTPListenPort:                 9192,
-		GRPCListenAddress:              "localhost",
-		HTTPMiddleware:                 []middleware.Interface{middleware.Logging},
-		MetricsNamespace:               "testing_logging",
-		LogLevel:                       level,
-		DisableGeneratedHTTPMiddleware: true,
-		Router:                         &mux.Router{},
+		HTTPListenAddress:             "localhost",
+		HTTPListenPort:                9192,
+		GRPCListenAddress:             "localhost",
+		HTTPMiddleware:                []middleware.Interface{middleware.Logging},
+		MetricsNamespace:              "testing_logging",
+		LogLevel:                      level,
+		DoNotAddDefaultHTTPMiddleware: true,
+		Router:                        &mux.Router{},
 	}
 	server, err := New(cfg)
 	require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
@@ -272,12 +274,14 @@ func TestMiddlewareLogging(t *testing.T) {
 	var level logging.Level
 	level.Set("info")
 	cfg := Config{
-		HTTPListenAddress: "localhost",
-		HTTPListenPort:    9192,
-		GRPCListenAddress: "localhost",
-		HTTPMiddleware:    []middleware.Interface{middleware.Logging},
-		MetricsNamespace:  "testing_logging",
-		LogLevel:          level,
+		HTTPListenAddress:              "localhost",
+		HTTPListenPort:                 9192,
+		GRPCListenAddress:              "localhost",
+		HTTPMiddleware:                 []middleware.Interface{middleware.Logging},
+		MetricsNamespace:               "testing_logging",
+		LogLevel:                       level,
+		DisableGeneratedHTTPMiddleware: true,
+		Router:                         &mux.Router{},
 	}
 	server, err := New(cfg)
 	require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,13 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	node_https "github.com/prometheus/node_exporter/https"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Add an option to change the Router and an option to not add the default middleware.

Signed-off-by: Michel Hollands <michel.hollands@grafana.com>
