### PR TITLE
Fixed aws.ConfigFromURL() when URL contains @ but no user/pass

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -40,9 +40,13 @@ func ConfigFromURL(awsURL *url.URL) (*aws.Config, error) {
 		})
 
 	if awsURL.User != nil {
+		username := awsURL.User.Username()
 		password, _ := awsURL.User.Password()
-		creds := credentials.NewStaticCredentials(awsURL.User.Username(), password, "")
-		config = config.WithCredentials(creds)
+
+		// We request at least the username or password being set to enable the static credentials.
+		if username != "" || password != "" {
+			config = config.WithCredentials(credentials.NewStaticCredentials(username, password, ""))
+		}
 	}
 
 	if strings.Contains(awsURL.Host, ".") {

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -25,6 +25,13 @@ func TestAWSConfigFromURL(t *testing.T) {
 			"http://s3.default.svc.cluster.local:4569",
 		},
 		{
+			"s3://@us-east-1/test-bucket",
+			"",
+			"",
+			"us-east-1",
+			"",
+		},
+		{
 			"dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000/cortex",
 			"user",
 			"pass",
@@ -54,10 +61,10 @@ func TestAWSConfigFromURL(t *testing.T) {
 			cfg, err := ConfigFromURL(parsedURL)
 			require.NoError(t, err)
 
-			if cfg.Credentials == nil {
-				assert.Equal(t, "", tc.expectedKey)
-				assert.Equal(t, "", tc.expectedSecret)
+			if tc.expectedKey == "" && tc.expectedSecret == "" {
+				assert.Nil(t, cfg.Credentials)
 			} else {
+				require.NotNil(t, cfg.Credentials)
 				val, err := cfg.Credentials.Get()
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedKey, val.AccessKeyID)
@@ -70,6 +77,8 @@ func TestAWSConfigFromURL(t *testing.T) {
 			if tc.expectedEp != "" {
 				require.NotNil(t, cfg.Endpoint)
 				assert.Equal(t, tc.expectedEp, *cfg.Endpoint)
+			} else {
+				assert.Nil(t, cfg.Endpoint)
 			}
 		})
 	}


### PR DESCRIPTION
Starting from an issue opened in Cortex https://github.com/cortexproject/cortex/issues/3034, I've realised an edge case in `aws.ConfigFromURL()`. If the URL is in the format `scheme://@host/path`, the static credentials are configured in the S3 config but with an empty ID / secret, because no user/pass is specified in the URL before the `@`.

In this PR I'm proposing a fix for that.