### PR TITLE
Uses a better body reader for the http request of the grpc server.

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -48,13 +48,12 @@ func nopCloserBuffer(b *bytes.Buffer) io.ReadCloser {
 	return nopCloser{b}
 }
 
-// BodyFromReader attempt to return the body as a bytes buffer to avoid reading and copying one that already exists.
-func BodyFromReader(r io.ReadCloser) (*bytes.Buffer, bool) {
+// BytesBufferFromReader attempt to return cast a reader as a bytes buffer to avoid reading and copying one that already exists.
+func BytesBufferFromReader(r io.ReadCloser) (*bytes.Buffer, bool) {
 	if nop, ok := r.(nopCloser); ok {
 		return nop.Buffer, ok
 	}
 	return nil, false
-
 }
 
 // Handle implements HTTPServer.

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -39,7 +39,7 @@ func NewServer(handler http.Handler) *Server {
 
 // Handle implements HTTPServer.
 func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
-	req, err := http.NewRequest(r.Method, r.Url, ioutil.NopCloser(bytes.NewReader(r.Body)))
+	req, err := http.NewRequest(r.Method, r.Url, bytes.NewBuffer(r.Body))
 	if err != nil {
 		return nil, err
 	}

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -48,7 +48,8 @@ func nopCloserBuffer(b *bytes.Buffer) io.ReadCloser {
 	return nopCloser{b}
 }
 
-// BytesBufferFromReader attempt to return cast a reader as a bytes buffer to avoid reading and copying one that already exists.
+// BytesBufferFromReader attempts to cast a `io.ReadCloser` as a `bytes.Buffer` to avoid reading and copying one that already exists.
+// In case of failure it will return nil and a false boolean.
 func BytesBufferFromReader(r io.ReadCloser) (*bytes.Buffer, bool) {
 	if nop, ok := r.(nopCloser); ok {
 		return nop.Buffer, ok


### PR DESCRIPTION
It might not be obvious but this small changes has a big impact:

1. if you read the `http.NewRequest` code you will realize that the content lenght is computed only if the body interface is from a specific type.

```go
if body != nil {
		switch v := body.(type) {
		case *bytes.Buffer:
			req.ContentLength = int64(v.Len())
			buf := v.Bytes()
			req.GetBody = func() (io.ReadCloser, error) {
				r := bytes.NewReader(buf)
				return ioutil.NopCloser(r), nil
			}
		case *bytes.Reader:
			req.ContentLength = int64(v.Len())
			snapshot := *v
			req.GetBody = func() (io.ReadCloser, error) {
				r := snapshot
				return ioutil.NopCloser(&r), nil
			}
		case *strings.Reader:
			req.ContentLength = int64(v.Len())
			snapshot := *v
			req.GetBody = func() (io.ReadCloser, error) {
				r := snapshot
				return ioutil.NopCloser(&r), nil
			}
		default:
			// This is where we'd set it to -1 (at least
			// if body != NoBody) to mean unknown, but
			// that broke people during the Go 1.8 testing
			// period. People depend on it being 0 I
			// guess. Maybe retry later. See Issue 18117.
		}

```

This means that until then, the `ContentLength` was not available to downstream handler.

2. I could have simply remove the useless `ioutil.NopCloser` but instead I replace it with `bytes.Buffer`. Now this means we don't need anymore to make a copy of the body if we want to use it. We can just cast it.

For example in Cortex this code https://github.com/cortexproject/cortex/blob/master/pkg/util/http.go#L94-L99 will never allocate properly the buffer and will make multiple allocations call while reading the body because `expectedSize` is always 0.

This happens in Loki too, and most likely in Tempo.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>