### PR TITLE
Set the content-length of httpgrpc request.

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -46,6 +46,7 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 	toHeader(r.Headers, req.Header)
 	req = req.WithContext(ctx)
 	req.RequestURI = r.Url
+	req.ContentLength = int64(len(r.Body))
 
 	recorder := httptest.NewRecorder()
 	s.handler.ServeHTTP(recorder, req)


### PR DESCRIPTION
http.NewRequest can't set it while using a `io.NopCloser`.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>