### PR TITLE
Replace `ioutil.NopCloser` with a custom one.

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -37,9 +37,18 @@ func NewServer(handler http.Handler) *Server {
 	}
 }
 
+type nopCloser struct {
+	*bytes.Buffer
+}
+
+func (nopCloser) Close() error { return nil }
+
+// BytesBuffer returns the underlaying `bytes.buffer` used to build this io.ReadCloser.
+func (n nopCloser) BytesBuffer() *bytes.Buffer { return n.Buffer }
+
 // Handle implements HTTPServer.
 func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
-	req, err := http.NewRequest(r.Method, r.Url, ioutil.NopCloser(bytes.NewReader(r.Body)))
+	req, err := http.NewRequest(r.Method, r.Url, nopCloser{Buffer: bytes.NewBuffer(r.Body)})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This way we can easily get direct access to the underlaying `bytes.Buffer`. This means we don't need to copy the data anymore.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>