### PR TITLE
Fix panic in server instrumentation matching NotFoundHandler

### DIFF
--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -104,17 +104,25 @@ func (i Instrument) getRouteName(r *http.Request) string {
 
 func getRouteName(routeMatcher RouteMatcher, r *http.Request) string {
 	var routeMatch mux.RouteMatch
-	if routeMatcher != nil && routeMatcher.Match(r, &routeMatch) {
-		if routeMatch.Route != nil {
-			if name := routeMatch.Route.GetName(); name != "" {
-				return name
-			}
-			if tmpl, err := routeMatch.Route.GetPathTemplate(); err == nil {
-				return MakeLabelValue(tmpl)
-			}
-		} else if routeMatch.MatchErr == mux.ErrNotFound {
-			return "notfound"
-		}
+	if routeMatcher == nil || !routeMatcher.Match(r, &routeMatch) {
+		return ""
+	}
+
+	if routeMatch.MatchErr == mux.ErrNotFound {
+		return "notfound"
+	}
+
+	if routeMatch.Route == nil {
+		return ""
+	}
+
+	if name := routeMatch.Route.GetName(); name != "" {
+		return name
+	}
+
+	tmpl, err := routeMatch.Route.GetPathTemplate()
+	if err == nil {
+		return MakeLabelValue(tmpl)
 	}
 
 	return ""

--- a/middleware/instrument.go
+++ b/middleware/instrument.go
@@ -105,11 +105,15 @@ func (i Instrument) getRouteName(r *http.Request) string {
 func getRouteName(routeMatcher RouteMatcher, r *http.Request) string {
 	var routeMatch mux.RouteMatch
 	if routeMatcher != nil && routeMatcher.Match(r, &routeMatch) {
-		if name := routeMatch.Route.GetName(); name != "" {
-			return name
-		}
-		if tmpl, err := routeMatch.Route.GetPathTemplate(); err == nil {
-			return MakeLabelValue(tmpl)
+		if routeMatch.Route != nil {
+			if name := routeMatch.Route.GetName(); name != "" {
+				return name
+			}
+			if tmpl, err := routeMatch.Route.GetPathTemplate(); err == nil {
+				return MakeLabelValue(tmpl)
+			}
+		} else if routeMatch.MatchErr == mux.ErrNotFound {
+			return "notfound"
 		}
 	}
 


### PR DESCRIPTION
When router can't find the route but it has the `NotFoundHandler` set, the `RouteMatch` doesn't have the `Route` set but it has `MatchErr` set to `ErrNotFound`.

Added a check for `RouteMatch.Route` to be not nil before accessing it, and added a special `"notfound"` route name to be used when `NotFoundHandler` is used.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>
