### PR TITLE
Add metric "tcp_connections" for number of TCP connections to server.

### DIFF
--- a/middleware/counting_listener.go
+++ b/middleware/counting_listener.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// CountingListener returns a Listener that increments a Prometheus gauge when
+// a connection is accepted, and decrements the gauge when the connection is closed.
+func CountingListener(l net.Listener, g prometheus.Gauge) net.Listener {
+	return &countingListener{Listener: l, gauge: g}
+}
+
+type countingListener struct {
+	net.Listener
+	gauge prometheus.Gauge
+}
+
+func (c *countingListener) Accept() (net.Conn, error) {
+	conn, err := c.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	c.gauge.Inc()
+	return &countingListenerConn{Conn: conn, gauge: c.gauge}, nil
+}
+
+type countingListenerConn struct {
+	net.Conn
+	gauge prometheus.Gauge
+	once  sync.Once
+}
+
+func (l *countingListenerConn) Close() error {
+	err := l.Conn.Close()
+
+	// Only ever decrement the gauge once in case of badly behaving callers.
+	l.once.Do(func() { l.gauge.Dec() })
+
+	return err
+}

--- a/middleware/counting_listener_test.go
+++ b/middleware/counting_listener_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeListener struct {
+	net.Listener
+	acceptErr error
+	closeErr  error
+}
+
+type fakeConn struct {
+	net.Conn
+	closeErr error
+}
+
+func (c *fakeConn) Close() error {
+	return c.closeErr
+}
+
+func (c *fakeListener) Accept() (net.Conn, error) {
+	return &fakeConn{closeErr: c.closeErr}, c.acceptErr
+}
+
+func TestCountingListener(t *testing.T) {
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "test",
+		Name:      "gauge",
+	})
+
+	fake := &fakeListener{}
+	l := CountingListener(fake, g)
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Accepting connections should increment the gauge.
+	c1, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	c2, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(2), testutil.ToFloat64(g))
+
+	// Closing connections should decrement the gauge.
+	assert.NoError(t, c1.Close())
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	assert.NoError(t, c2.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Duplicate calls to Close should not decrement.
+	assert.NoError(t, c1.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Accept errors should not cause an increment.
+	fake.acceptErr = errors.New("accept")
+	_, err = l.Accept()
+	assert.Error(t, err)
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+
+	// Close errors should still decrement.
+	fake.acceptErr = nil
+	fake.closeErr = errors.New("close")
+	c3, err := l.Accept()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(g))
+	assert.Error(t, c3.Close())
+	assert.Equal(t, float64(0), testutil.ToFloat64(g))
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -389,7 +389,12 @@ func TestHTTPInstrumentationMetrics(t *testing.T) {
 		response_message_bytes_bucket{method="GET",route="succeed",le="+Inf"} 1
 		response_message_bytes_sum{method="GET",route="succeed"} 2
 		response_message_bytes_count{method="GET",route="succeed"} 1
-	`), "request_message_bytes", "response_message_bytes", "inflight_requests"))
+
+		# HELP tcp_connections Current number of accepted TCP connections.
+		# TYPE tcp_connections gauge
+		tcp_connections{protocol="http"} 0
+		tcp_connections{protocol="grpc"} 0
+	`), "request_message_bytes", "response_message_bytes", "inflight_requests", "tcp_connections"))
 }
 
 func TestRunReturnsError(t *testing.T) {


### PR DESCRIPTION
Counts the number of accepted connections and the number of closed
connections, by intercepting the listener for each port (http/grpc).

Signed-off-by: Steve Simpson <steve.simpson@grafana.com>