### PR TITLE
Add exemplars to 'instrument' package and gRPC interceptors

### DIFF
--- a/instrument/instrument_test.go
+++ b/instrument/instrument_test.go
@@ -34,12 +34,12 @@ func (c *spyCollector) Register() {
 }
 
 // Before collects for the upcoming request.
-func (c *spyCollector) Before(method string, start time.Time) {
+func (c *spyCollector) Before(ctx context.Context, method string, start time.Time) {
 	c.before = true
 }
 
 // After collects when the request is done.
-func (c *spyCollector) After(method, statusCode string, start time.Time) {
+func (c *spyCollector) After(ctx context.Context, method, statusCode string, start time.Time) {
 	c.after = true
 	c.afterCode = statusCode
 }

--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
-	jaeger "github.com/uber/jaeger-client-go"
-	"golang.org/x/net/context"
 )
 
 // Dummy dependency to enforce that we have a nethttp version newer
@@ -39,33 +37,4 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 	}
 
 	return nethttp.Middleware(opentracing.GlobalTracer(), next, options...)
-}
-
-// ExtractTraceID extracts the trace id, if any from the context.
-func ExtractTraceID(ctx context.Context) (string, bool) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp == nil {
-		return "", false
-	}
-	sctx, ok := sp.Context().(jaeger.SpanContext)
-	if !ok {
-		return "", false
-	}
-
-	return sctx.TraceID().String(), true
-}
-
-// ExtractSampledTraceID works like ExtractTraceID but the returned bool is only
-// true if the returned trace id is sampled.
-func ExtractSampledTraceID(ctx context.Context) (string, bool) {
-	sp := opentracing.SpanFromContext(ctx)
-	if sp == nil {
-		return "", false
-	}
-	sctx, ok := sp.Context().(jaeger.SpanContext)
-	if !ok {
-		return "", false
-	}
-
-	return sctx.TraceID().String(), sctx.IsSampled()
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/tracing"
 	"github.com/weaveworks/common/user"
 )
 
@@ -21,7 +22,7 @@ type Log struct {
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) logging.Interface {
 	localLog := l.Log
-	traceID, ok := ExtractTraceID(r.Context())
+	traceID, ok := tracing.ExtractTraceID(r.Context())
 	if ok {
 		localLog = localLog.WithField("traceID", traceID)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -258,8 +258,8 @@ func New(cfg Config) (*Server, error) {
 	}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
-		middleware.UnaryServerInstrumentInterceptor(requestDuration),
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
+		middleware.UnaryServerInstrumentInterceptor(requestDuration),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 


### PR DESCRIPTION
Whenever a duration is observed and we have a trace ID, store it as a Prometheus exemplar.

Follow-up to #202 

This is a breaking change to the `Collector` interface and the location of `ExtractTraceID`; apologies if you are impacted.
I felt the `middleware` package should not be a dependency of `instrument`, and the assumption that traces are Jaeger is better placed in the `tracing` package where we set up Jaeger.

Note also that the gRPC code path creates a trace before recording the histogram time, instead of the other way round.
I don't expect this will have any measurable effect.