### PR TITLE
Allow blank network in server.New

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -171,8 +171,12 @@ func New(cfg Config) (*Server, error) {
 	}, []string{"protocol"})
 	prometheus.MustRegister(tcpConnections)
 
+	network := cfg.HTTPListenNetwork
+	if network == "" {
+		network = DefaultNetwork
+	}
 	// Setup listeners first, so we can fail early if the port is in use.
-	httpListener, err := net.Listen(cfg.HTTPListenNetwork, fmt.Sprintf("%s:%d", cfg.HTTPListenAddress, cfg.HTTPListenPort))
+	httpListener, err := net.Listen(network, fmt.Sprintf("%s:%d", cfg.HTTPListenAddress, cfg.HTTPListenPort))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +186,11 @@ func New(cfg Config) (*Server, error) {
 		httpListener = netutil.LimitListener(httpListener, cfg.HTTPConnLimit)
 	}
 
-	grpcListener, err := net.Listen(cfg.HTTPListenNetwork, fmt.Sprintf("%s:%d", cfg.GRPCListenAddress, cfg.GRPCListenPort))
+	network = cfg.GRPCListenNetwork
+	if network == "" {
+		network = DefaultNetwork
+	}
+	grpcListener, err := net.Listen(network, fmt.Sprintf("%s:%d", cfg.GRPCListenAddress, cfg.GRPCListenPort))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There are a lot of tests which create a `server.Config{}` and don't populate the network fields; allow this by setting `DefaultNetwork` if blank.

Also pick up a bugfix where `HTTPListenNetwork` was used for gRPC.

