### PR TITLE
gRPC stream middleware: move metrics after tracing

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -273,8 +273,8 @@ func New(cfg Config) (*Server, error) {
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
 		serverLog.StreamServerInterceptor,
-		middleware.StreamServerInstrumentInterceptor(requestDuration),
 		otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer()),
+		middleware.StreamServerInstrumentInterceptor(requestDuration),
 	}
 	grpcStreamMiddleware = append(grpcStreamMiddleware, cfg.GRPCStreamMiddleware...)
 


### PR DESCRIPTION
So that we can pass the trace ID as an exemplar.

This was done for unary RPCs in #220 but I missed the stream case.