### PR TITLE
Request logging is not debug info

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -64,7 +64,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			return
 		}
 		if 100 <= statusCode && statusCode < 500 || statusCode == http.StatusBadGateway || statusCode == http.StatusServiceUnavailable {
-			l.logWithRequest(r).Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			l.logWithRequest(r).Infof("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
 			if l.LogRequestHeaders && headers != nil {
 				l.logWithRequest(r).Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
 			}

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -26,7 +26,7 @@ func TestBadWriteLogging(t *testing.T) {
 		logContains: []string{"warning", "error: yolo"},
 	}, {
 		err:         nil,
-		logContains: []string{"debug", "GET http://example.com/foo (200)"},
+		logContains: []string{"info", "GET http://example.com/foo (200)"},
 	}} {
 		buf := bytes.NewBuffer(nil)
 		logrusLogger := logrus.New()


### PR DESCRIPTION
It's voluminous, sure, but it's not just for debugging. Especially things like 4xx
requests.