### PR TITLE
Speed up debug logging, when filtered out

### DIFF
--- a/logging/gokit.go
+++ b/logging/gokit.go
@@ -17,6 +17,11 @@ func NewGoKitFormat(l Level, f Format) Interface {
 	} else {
 		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	}
+	return addStandardFields(logger, l)
+}
+
+// stand-alone for test purposes
+func addStandardFields(logger log.Logger, l Level) Interface {
 	logger = level.NewFilter(logger, l.Gokit)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 	return gokit{logger}

--- a/logging/gokit.go
+++ b/logging/gokit.go
@@ -22,8 +22,8 @@ func NewGoKitFormat(l Level, f Format) Interface {
 
 // stand-alone for test purposes
 func addStandardFields(logger log.Logger, l Level) Interface {
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(5))
 	logger = level.NewFilter(logger, l.Gokit)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
 	return gokit{logger}
 }
 

--- a/logging/gokit.go
+++ b/logging/gokit.go
@@ -41,32 +41,52 @@ type gokit struct {
 	log.Logger
 }
 
+// Helper to defer sprintf until it is needed.
+type sprintf struct {
+	format string
+	args   []interface{}
+}
+
+func (s *sprintf) String() string {
+	return fmt.Sprintf(s.format, s.args...)
+}
+
+// Helper to defer sprint until it is needed.
+// Note we don't use Sprintln because the output is passed to go-kit as one value among many on a line
+type sprint struct {
+	args []interface{}
+}
+
+func (s *sprint) String() string {
+	return fmt.Sprint(s.args...)
+}
+
 func (g gokit) Debugf(format string, args ...interface{}) {
-	level.Debug(g.Logger).Log("msg", fmt.Sprintf(format, args...))
+	level.Debug(g.Logger).Log("msg", &sprintf{format: format, args: args})
 }
 func (g gokit) Debugln(args ...interface{}) {
-	level.Debug(g.Logger).Log("msg", fmt.Sprintln(args...))
+	level.Debug(g.Logger).Log("msg", &sprint{args: args})
 }
 
 func (g gokit) Infof(format string, args ...interface{}) {
-	level.Info(g.Logger).Log("msg", fmt.Sprintf(format, args...))
+	level.Info(g.Logger).Log("msg", &sprintf{format: format, args: args})
 }
 func (g gokit) Infoln(args ...interface{}) {
-	level.Info(g.Logger).Log("msg", fmt.Sprintln(args...))
+	level.Info(g.Logger).Log("msg", &sprint{args: args})
 }
 
 func (g gokit) Warnf(format string, args ...interface{}) {
-	level.Warn(g.Logger).Log("msg", fmt.Sprintf(format, args...))
+	level.Warn(g.Logger).Log("msg", &sprintf{format: format, args: args})
 }
 func (g gokit) Warnln(args ...interface{}) {
-	level.Warn(g.Logger).Log("msg", fmt.Sprintln(args...))
+	level.Warn(g.Logger).Log("msg", &sprint{args: args})
 }
 
 func (g gokit) Errorf(format string, args ...interface{}) {
-	level.Error(g.Logger).Log("msg", fmt.Sprintf(format, args...))
+	level.Error(g.Logger).Log("msg", &sprintf{format: format, args: args})
 }
 func (g gokit) Errorln(args ...interface{}) {
-	level.Error(g.Logger).Log("msg", fmt.Sprintln(args...))
+	level.Error(g.Logger).Log("msg", &sprint{args: args})
 }
 
 func (g gokit) WithField(key string, value interface{}) Interface {

--- a/logging/gokit_test.go
+++ b/logging/gokit_test.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+func BenchmarkDebugf(b *testing.B) {
+	lvl := Level{Gokit: level.AllowInfo()}
+	g := log.NewNopLogger()
+	logger := addStandardFields(g, lvl)
+	// Simulate the parameters used in middleware/logging.go
+	var (
+		method     = "method"
+		uri        = "https://example.com/foobar"
+		statusCode = 404
+		duration   = 42
+	)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Debugf("%s %s (%d) %s", method, uri, statusCode, duration)
+	}
+}


### PR DESCRIPTION
A benchmark, plus two changes:
 * Filter by log level before anything else - this saves a lot of work walking the stack to find the caller, and a bit more to format the timestamp.  As recommended at https://github.com/go-kit/log/issues/14#issuecomment-945038252
 * Avoid Sprintf when log line is filtered out - defer the Sprintf until after the level check by using an auxilliary struct.

Benchmark results:
```
name      old time/op    new time/op    delta
Debugf-4    2.46µs ± 6%    0.54µs ± 6%  -78.00%  (p=0.008 n=5+5)

name      old alloc/op   new alloc/op   delta
Debugf-4      848B ± 0%      328B ± 0%  -61.32%  (p=0.008 n=5+5)

name      old allocs/op  new allocs/op  delta
Debugf-4      15.0 ± 0%       9.0 ± 0%  -40.00%  (p=0.008 n=5+5)
```

Small improvement in behaviour for `Infoln()`, `Warningln()`, etc.: they no longer add a newline character to the string. Go-kit log lines are intrinsically a single line, with structured fields so it's wrong to add a newline.
Previously this would come out as `msg="My log message\n"` in the log.