### PR TITLE
Add a tag with the user-agent to traces

### DIFF
--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -29,19 +29,19 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 
 			return fmt.Sprintf("HTTP %s - %s", r.Method, op)
 		}),
-		// add a tag with the clients user agent to the span
 		nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
+			// add a tag with the client's user agent to the span
 			userAgent := r.Header.Get("User-Agent")
 			if userAgent != "" {
 				sp.SetTag("http.user_agent", userAgent)
 			}
-		}),
-	}
 
-	if t.SourceIPs != nil {
-		options = append(options, nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
-			sp.SetTag("sourceIPs", t.SourceIPs.Get(r))
-		}))
+			// add a tag with the client's sourceIPs to the span, if a
+			// SourceIPExtractor is given.
+			if t.SourceIPs != nil {
+				sp.SetTag("sourceIPs", t.SourceIPs.Get(r))
+			}
+		}),
 	}
 
 	return nethttp.Middleware(opentracing.GlobalTracer(), next, options...)

--- a/middleware/http_tracing.go
+++ b/middleware/http_tracing.go
@@ -29,7 +29,15 @@ func (t Tracer) Wrap(next http.Handler) http.Handler {
 
 			return fmt.Sprintf("HTTP %s - %s", r.Method, op)
 		}),
+		// add a tag with the clients user agent to the span
+		nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
+			userAgent := r.Header.Get("User-Agent")
+			if userAgent != "" {
+				sp.SetTag("http.user_agent", userAgent)
+			}
+		}),
 	}
+
 	if t.SourceIPs != nil {
 		options = append(options, nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
 			sp.SetTag("sourceIPs", t.SourceIPs.Get(r))


### PR DESCRIPTION
Often it can be useful to understand, which kind of client is behaving in a certain way.

That's why this PR adds a tag to the HTTP trace middleware to annotate the span with the user-agent header of the request.
