### PR TITLE
Add flag to log requests at info level

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -14,10 +14,10 @@ import (
 
 // Log middleware logs http requests
 type Log struct {
-	Log                    logging.Interface
-	LogRequestHeaders      bool // LogRequestHeaders true -> dump http headers at debug log level
-	LogRequestsAtInfoLevel bool // LogRequestAtInfoLevel true -> log requests at info log level
-	SourceIPs              *SourceIPExtractor
+	Log                   logging.Interface
+	LogRequestHeaders     bool // LogRequestHeaders true -> dump http headers at debug log level
+	LogRequestAtInfoLevel bool // LogRequestAtInfoLevel true -> log requests at info log level
+	SourceIPs             *SourceIPExtractor
 }
 
 // logWithRequest information from the request and context as fields.
@@ -43,11 +43,12 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		begin := time.Now()
 		uri := r.RequestURI // capture the URI before running next, as it may get rewritten
+		requestLog := l.logWithRequest(r)
 		// Log headers before running 'next' in case other interceptors change the data.
 		headers, err := dumpRequest(r)
 		if err != nil {
 			headers = nil
-			l.logWithRequest(r).Errorf("Could not dump request headers: %v", err)
+			requestLog.Errorf("Could not dump request headers: %v", err)
 		}
 		var buf bytes.Buffer
 		wrapped := newBadResponseLoggingWriter(w, &buf)
@@ -57,32 +58,32 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 
 		if writeErr != nil {
 			if errors.Is(writeErr, context.Canceled) {
-				if l.LogRequestsAtInfoLevel {
-					l.logWithRequest(r).Infof("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+				if l.LogRequestAtInfoLevel {
+					requestLog.Infof("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
 				} else {
-					l.logWithRequest(r).Debugf("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+					requestLog.Debugf("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
 				}
 			} else {
-				l.logWithRequest(r).Warnf("%s %s %s, error: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+				requestLog.Warnf("%s %s %s, error: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
 			}
 
 			return
 		}
 		if 100 <= statusCode && statusCode < 500 || statusCode == http.StatusBadGateway || statusCode == http.StatusServiceUnavailable {
-			if l.LogRequestsAtInfoLevel {
-				l.logWithRequest(r).Infof("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			if l.LogRequestAtInfoLevel {
+				requestLog.Infof("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
 			} else {
-				l.logWithRequest(r).Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+				requestLog.Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
 			}
 			if l.LogRequestHeaders && headers != nil {
-				if l.LogRequestsAtInfoLevel {
-					l.logWithRequest(r).Infof("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+				if l.LogRequestAtInfoLevel {
+					requestLog.Infof("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
 				} else {
-					l.logWithRequest(r).Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+					requestLog.Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
 				}
 			}
 		} else {
-			l.logWithRequest(r).Warnf("%s %s (%d) %s Response: %q ws: %v; %s",
+			requestLog.Warnf("%s %s (%d) %s Response: %q ws: %v; %s",
 				r.Method, uri, statusCode, time.Since(begin), buf.Bytes(), IsWSHandshakeRequest(r), headers)
 		}
 	})

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -16,7 +16,7 @@ import (
 type Log struct {
 	Log                    logging.Interface
 	LogRequestHeaders      bool // LogRequestHeaders true -> dump http headers at debug log level
-	LogRequestsAtInfoLevel bool // LogRequestAtInfoLevel true -> dump requests at info log level
+	LogRequestsAtInfoLevel bool // LogRequestAtInfoLevel true -> log requests at info log level
 	SourceIPs              *SourceIPExtractor
 }
 

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -38,15 +38,6 @@ func (l Log) logWithRequest(r *http.Request) logging.Interface {
 	return user.LogWith(r.Context(), localLog)
 }
 
-func (l Log) logWithRequestAtLevelf(r *http.Request, level string, format string, args ...interface{}) {
-	switch level {
-	case "debug":
-		l.logWithRequest(r).Debugf(format, args...)
-	case "info":
-		l.logWithRequest(r).Infof(format, args...)
-	}
-}
-
 // Wrap implements Middleware
 func (l Log) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -62,16 +53,15 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		wrapped := newBadResponseLoggingWriter(w, &buf)
 		next.ServeHTTP(wrapped, r)
 
-		level := "debug"
-		if l.LogRequestsAtInfoLevel {
-			level = "info"
-		}
-
 		statusCode, writeErr := wrapped.statusCode, wrapped.writeError
 
 		if writeErr != nil {
 			if errors.Is(writeErr, context.Canceled) {
-				l.logWithRequestAtLevelf(r, level, "%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+				if l.LogRequestsAtInfoLevel {
+					l.logWithRequest(r).Infof("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+				} else {
+					l.logWithRequest(r).Debugf("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
+				}
 			} else {
 				l.logWithRequest(r).Warnf("%s %s %s, error: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)
 			}
@@ -79,9 +69,17 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 			return
 		}
 		if 100 <= statusCode && statusCode < 500 || statusCode == http.StatusBadGateway || statusCode == http.StatusServiceUnavailable {
-			l.logWithRequestAtLevelf(r, level, "%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			if l.LogRequestsAtInfoLevel {
+				l.logWithRequest(r).Infof("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			} else {
+				l.logWithRequest(r).Debugf("%s %s (%d) %s", r.Method, uri, statusCode, time.Since(begin))
+			}
 			if l.LogRequestHeaders && headers != nil {
-				l.logWithRequestAtLevelf(r, level, "ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+				if l.LogRequestsAtInfoLevel {
+					l.logWithRequest(r).Infof("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+				} else {
+					l.logWithRequest(r).Debugf("ws: %v; %s", IsWSHandshakeRequest(r), string(headers))
+				}
 			}
 		} else {
 			l.logWithRequest(r).Warnf("%s %s (%d) %s Response: %q ws: %v; %s",

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -73,8 +73,8 @@ func TestLoggingRequestsAtInfoLevel(t *testing.T) {
 		logrusLogger.Level = logrus.DebugLevel
 
 		loggingMiddleware := Log{
-			Log:                    logging.Logrus(logrusLogger),
-			LogRequestsAtInfoLevel: true,
+			Log:                   logging.Logrus(logrusLogger),
+			LogRequestAtInfoLevel: true,
 		}
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			io.WriteString(w, "<html><body>Hello World!</body></html>")

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -54,7 +54,46 @@ func TestBadWriteLogging(t *testing.T) {
 			require.True(t, bytes.Contains(buf.Bytes(), []byte(content)))
 		}
 	}
+}
 
+func TestLoggingRequestsAtInfoLevel(t *testing.T) {
+	for _, tc := range []struct {
+		err         error
+		logContains []string
+	}{{
+		err:         context.Canceled,
+		logContains: []string{"info", "request cancelled: context canceled"},
+	}, {
+		err:         nil,
+		logContains: []string{"info", "GET http://example.com/foo (200)"},
+	}} {
+		buf := bytes.NewBuffer(nil)
+		logrusLogger := logrus.New()
+		logrusLogger.Out = buf
+		logrusLogger.Level = logrus.DebugLevel
+
+		loggingMiddleware := Log{
+			Log:                    logging.Logrus(logrusLogger),
+			LogRequestsAtInfoLevel: true,
+		}
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "<html><body>Hello World!</body></html>")
+		}
+		loggingHandler := loggingMiddleware.Wrap(http.HandlerFunc(handler))
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		recorder := httptest.NewRecorder()
+
+		w := errorWriter{
+			err: tc.err,
+			w:   recorder,
+		}
+		loggingHandler.ServeHTTP(w, req)
+
+		for _, content := range tc.logContains {
+			require.True(t, bytes.Contains(buf.Bytes(), []byte(content)))
+		}
+	}
 }
 
 type errorWriter struct {

--- a/server/server.go
+++ b/server/server.go
@@ -91,13 +91,13 @@ type Config struct {
 	GRPCServerMinTimeBetweenPings      time.Duration `yaml:"grpc_server_min_time_between_pings"`
 	GRPCServerPingWithoutStreamAllowed bool          `yaml:"grpc_server_ping_without_stream_allowed"`
 
-	LogFormat              logging.Format    `yaml:"log_format"`
-	LogLevel               logging.Level     `yaml:"log_level"`
-	Log                    logging.Interface `yaml:"-"`
-	LogSourceIPs           bool              `yaml:"log_source_ips_enabled"`
-	LogSourceIPsHeader     string            `yaml:"log_source_ips_header"`
-	LogSourceIPsRegex      string            `yaml:"log_source_ips_regex"`
-	LogRequestsAtInfoLevel bool              `yaml:"log_requests_at_info_level_enabled"`
+	LogFormat             logging.Format    `yaml:"log_format"`
+	LogLevel              logging.Level     `yaml:"log_level"`
+	Log                   logging.Interface `yaml:"-"`
+	LogSourceIPs          bool              `yaml:"log_source_ips_enabled"`
+	LogSourceIPsHeader    string            `yaml:"log_source_ips_header"`
+	LogSourceIPsRegex     string            `yaml:"log_source_ips_regex"`
+	LogRequestAtInfoLevel bool              `yaml:"log_request_at_info_level_enabled"`
 
 	// If not set, default signal handler is used.
 	SignalHandler SignalHandler `yaml:"-"`
@@ -150,7 +150,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogSourceIPs, "server.log-source-ips-enabled", false, "Optionally log the source IPs.")
 	f.StringVar(&cfg.LogSourceIPsHeader, "server.log-source-ips-header", "", "Header field storing the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
 	f.StringVar(&cfg.LogSourceIPsRegex, "server.log-source-ips-regex", "", "Regex for matching the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
-	f.BoolVar(&cfg.LogRequestsAtInfoLevel, "server.log-requests-at-info-level", false, "Optionally log requests at info level instead of debug level.")
+	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log_request_at_info_level_enabled", false, "Optionally log requests at info level instead of debug level.")
 }
 
 // Server wraps a HTTP and gRPC server, and some common initialization.
@@ -369,9 +369,9 @@ func New(cfg Config) (*Server, error) {
 			SourceIPs:    sourceIPs,
 		},
 		middleware.Log{
-			Log:                    log,
-			SourceIPs:              sourceIPs,
-			LogRequestsAtInfoLevel: cfg.LogRequestsAtInfoLevel,
+			Log:                   log,
+			SourceIPs:             sourceIPs,
+			LogRequestAtInfoLevel: cfg.LogRequestAtInfoLevel,
 		},
 		middleware.Instrument{
 			RouteMatcher:     router,

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type Config struct {
 	HTTPMiddleware                []middleware.Interface         `yaml:"-"`
 	Router                        *mux.Router                    `yaml:"-"`
 	DoNotAddDefaultHTTPMiddleware bool                           `yaml:"-"`
+	LogRequestsAtInfoLevel        bool                           `yaml:"-"`
 
 	GPRCServerMaxRecvMsgSize           int           `yaml:"grpc_server_max_recv_msg_size"`
 	GRPCServerMaxSendMsgSize           int           `yaml:"grpc_server_max_send_msg_size"`
@@ -367,8 +368,9 @@ func New(cfg Config) (*Server, error) {
 			SourceIPs:    sourceIPs,
 		},
 		middleware.Log{
-			Log:       log,
-			SourceIPs: sourceIPs,
+			Log:                    log,
+			SourceIPs:              sourceIPs,
+			LogRequestsAtInfoLevel: cfg.LogRequestsAtInfoLevel,
 		},
 		middleware.Instrument{
 			RouteMatcher:     router,

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,6 @@ type Config struct {
 	HTTPMiddleware                []middleware.Interface         `yaml:"-"`
 	Router                        *mux.Router                    `yaml:"-"`
 	DoNotAddDefaultHTTPMiddleware bool                           `yaml:"-"`
-	LogRequestsAtInfoLevel        bool                           `yaml:"-"`
 
 	GPRCServerMaxRecvMsgSize           int           `yaml:"grpc_server_max_recv_msg_size"`
 	GRPCServerMaxSendMsgSize           int           `yaml:"grpc_server_max_send_msg_size"`
@@ -92,12 +91,13 @@ type Config struct {
 	GRPCServerMinTimeBetweenPings      time.Duration `yaml:"grpc_server_min_time_between_pings"`
 	GRPCServerPingWithoutStreamAllowed bool          `yaml:"grpc_server_ping_without_stream_allowed"`
 
-	LogFormat          logging.Format    `yaml:"log_format"`
-	LogLevel           logging.Level     `yaml:"log_level"`
-	Log                logging.Interface `yaml:"-"`
-	LogSourceIPs       bool              `yaml:"log_source_ips_enabled"`
-	LogSourceIPsHeader string            `yaml:"log_source_ips_header"`
-	LogSourceIPsRegex  string            `yaml:"log_source_ips_regex"`
+	LogFormat              logging.Format    `yaml:"log_format"`
+	LogLevel               logging.Level     `yaml:"log_level"`
+	Log                    logging.Interface `yaml:"-"`
+	LogSourceIPs           bool              `yaml:"log_source_ips_enabled"`
+	LogSourceIPsHeader     string            `yaml:"log_source_ips_header"`
+	LogSourceIPsRegex      string            `yaml:"log_source_ips_regex"`
+	LogRequestsAtInfoLevel bool              `yaml:"log_requests_at_info_level_enabled"`
 
 	// If not set, default signal handler is used.
 	SignalHandler SignalHandler `yaml:"-"`
@@ -150,6 +150,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogSourceIPs, "server.log-source-ips-enabled", false, "Optionally log the source IPs.")
 	f.StringVar(&cfg.LogSourceIPsHeader, "server.log-source-ips-header", "", "Header field storing the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
 	f.StringVar(&cfg.LogSourceIPsRegex, "server.log-source-ips-regex", "", "Regex for matching the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
+	f.BoolVar(&cfg.LogRequestsAtInfoLevel, "server.log-requests-at-info-level", false, "Optionally log requests at info level instead of debug level.")
 }
 
 // Server wraps a HTTP and gRPC server, and some common initialization.

--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.LogSourceIPs, "server.log-source-ips-enabled", false, "Optionally log the source IPs.")
 	f.StringVar(&cfg.LogSourceIPsHeader, "server.log-source-ips-header", "", "Header field storing the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
 	f.StringVar(&cfg.LogSourceIPsRegex, "server.log-source-ips-regex", "", "Regex for matching the source IPs. Only used if server.log-source-ips-enabled is true. If not set the default Forwarded, X-Real-IP and X-Forwarded-For headers are used")
-	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log_request_at_info_level_enabled", false, "Optionally log requests at info level instead of debug level.")
+	f.BoolVar(&cfg.LogRequestAtInfoLevel, "server.log-request-at-info-level-enabled", false, "Optionally log requests at info level instead of debug level.")
 }
 
 // Server wraps a HTTP and gRPC server, and some common initialization.


### PR DESCRIPTION
Adds an optional flag to log requests at the info level, still defaulting to logging requests at the debug level. 