### PR TITLE
Add user and org labels to observed exemplars

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -68,9 +68,16 @@ func (c *HistogramCollector) After(ctx context.Context, method, statusCode strin
 // (this will always work for a HistogramVec).
 func ObserveWithExemplar(ctx context.Context, histogram prometheus.Observer, seconds float64) {
 	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
+		lbls := prometheus.Labels{"traceID": traceID}
+		if userID, err := user.ExtractUserID(ctx); err == nil {
+			lbls["user"] = userID
+		}
+		if orgID, err := user.ExtractOrgID(ctx); err == nil {
+			lbls["organization"] = orgID
+		}
 		histogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
 			seconds,
-			prometheus.Labels{"traceID": traceID},
+			lbls,
 		)
 		return
 	}


### PR DESCRIPTION
Exemplars provide information about traces, and traces usually reference to the user that served the request, however, searching the user in the trace is usually a tedious task, and it would be nice to be able to overwiew whether the slow requests (exemplars) from your panel corresponds to the same user.

We could even consider adding exemplars from non-traced requests that have a user ID? This would provide (poor) insights about the request patterns even for the users who run the server without tracing set up.