### PR TITLE
Removed debug log on successfuly gRPC requests from GRPCServerLog

### DIFF
--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"google.golang.org/grpc"
+
+	"github.com/weaveworks/common/logging"
+)
+
+func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
+	logger := logging.GoKit(level.NewFilter(log.NewNopLogger(), level.AllowError()))
+	l := GRPCServerLog{Log: logger, WithRequest: false}
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_, _ = l.UnaryServerInterceptor(ctx, nil, info, handler)
+	}
+}


### PR DESCRIPTION
Yesterday I was looking at memory allocations (bytes & objects) in Mimir ingesters with an high volume of small requests, and I've noticed memory allocations triggered by `GRPCServerLog` are non negligible. In this scenario, logging a successful request with debug level (which is then discarded by the filter because we configure logger min level = info) results in about 4% memory allocations:

![Screenshot 2022-05-20 at 10 39 17](https://user-images.githubusercontent.com/1701904/169489479-7b82206c-3e23-40be-b68d-1025cd9d3e71.png)

What's the sentiment if we remove the debug log on successful gRPC requests at all?
