### PR TITLE
httpgrpc.HTTPResponse from context.Canceled error

### DIFF
--- a/httpgrpc/httpgrpc_test.go
+++ b/httpgrpc/httpgrpc_test.go
@@ -1,0 +1,19 @@
+package httpgrpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPResponseFromError(t *testing.T) {
+	t.Run("context canceled", func(t *testing.T) {
+		err := fmt.Errorf("something failed: %w", context.Canceled)
+		resp, ok := HTTPResponseFromError(err)
+		require.True(t, ok)
+		require.Equal(t, int32(StatusClientClosedRequest), resp.Code)
+		require.Equal(t, err.Error(), string(resp.Body))
+	})
+}


### PR DESCRIPTION
Extends `httpgrpc.HTTPResponseFromError` functionality to map `context.Canceled` errors to 499 status code responses.

I think this makes sense in every situation, and will make all usages much easier, however on the other hand I think this goes beyond the responsibilities of this package.

I'd like to hear opinions on it.