### PR TITLE
Make debug logs on successful requests from GRPCServerLog optional

### DIFF
--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -20,15 +20,15 @@ const (
 type GRPCServerLog struct {
 	Log logging.Interface
 	// WithRequest will log the entire request rather than just the error
-	WithRequest bool
-	EnableDebug bool
+	WithRequest              bool
+	DisableRequestSuccessLog bool
 }
 
 // UnaryServerInterceptor returns an interceptor that logs gRPC requests
 func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	begin := time.Now()
 	resp, err := handler(ctx, req)
-	if err == nil && !s.EnableDebug {
+	if err == nil && s.DisableRequestSuccessLog {
 		return resp, nil
 	}
 
@@ -52,7 +52,7 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 func (s GRPCServerLog) StreamServerInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	begin := time.Now()
 	err := handler(srv, ss)
-	if err == nil && !s.EnableDebug {
+	if err == nil && s.DisableRequestSuccessLog {
 		return nil
 	}
 

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -13,7 +13,7 @@ import (
 
 func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 	logger := logging.GoKit(level.NewFilter(log.NewNopLogger(), level.AllowError()))
-	l := GRPCServerLog{Log: logger, WithRequest: false}
+	l := GRPCServerLog{Log: logger, WithRequest: false, EnableDebug: false}
 	ctx := context.Background()
 	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
 

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -13,7 +13,7 @@ import (
 
 func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 	logger := logging.GoKit(level.NewFilter(log.NewNopLogger(), level.AllowError()))
-	l := GRPCServerLog{Log: logger, WithRequest: false, EnableDebug: false}
+	l := GRPCServerLog{Log: logger, WithRequest: false, DisableRequestSuccessLog: true}
 	ctx := context.Background()
 	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
 

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"google.golang.org/grpc"
+
+	"github.com/weaveworks/common/logging"
+)
+
+func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
+	logger := logging.GoKit(level.NewFilter(log.NewNopLogger(), level.AllowError()))
+	l := GRPCServerLog{Log: logger, WithRequest: false}
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_, _ = l.UnaryServerInterceptor(ctx, nil, info, handler)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -289,9 +289,9 @@ func New(cfg Config) (*Server, error) {
 
 	// Setup gRPC server
 	serverLog := middleware.GRPCServerLog{
-		Log:         log,
-		WithRequest: !cfg.ExcludeRequestInLog,
-		EnableDebug: cfg.EnableSuccessfulDebugLog,
+		Log:                      log,
+		WithRequest:              !cfg.ExcludeRequestInLog,
+		DisableRequestSuccessLog: cfg.DisableRequestSuccessLog,
 	}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,

--- a/server/server.go
+++ b/server/server.go
@@ -65,8 +65,9 @@ type Config struct {
 	HTTPTLSConfig web.TLSStruct `yaml:"http_tls_config"`
 	GRPCTLSConfig web.TLSStruct `yaml:"grpc_tls_config"`
 
-	RegisterInstrumentation bool `yaml:"register_instrumentation"`
-	ExcludeRequestInLog     bool `yaml:"-"`
+	RegisterInstrumentation  bool `yaml:"register_instrumentation"`
+	ExcludeRequestInLog      bool `yaml:"-"`
+	EnableSuccessfulDebugLog bool `yaml:"-"`
 
 	ServerGracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
 	HTTPServerReadTimeout         time.Duration `yaml:"http_server_read_timeout"`
@@ -288,8 +289,9 @@ func New(cfg Config) (*Server, error) {
 
 	// Setup gRPC server
 	serverLog := middleware.GRPCServerLog{
-		WithRequest: !cfg.ExcludeRequestInLog,
 		Log:         log,
+		WithRequest: !cfg.ExcludeRequestInLog,
+		EnableDebug: cfg.EnableSuccessfulDebugLog,
 	}
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,

--- a/server/server.go
+++ b/server/server.go
@@ -67,7 +67,7 @@ type Config struct {
 
 	RegisterInstrumentation  bool `yaml:"register_instrumentation"`
 	ExcludeRequestInLog      bool `yaml:"-"`
-	EnableSuccessfulDebugLog bool `yaml:"-"`
+	DisableRequestSuccessLog bool `yaml:"-"`
 
 	ServerGracefulShutdownTimeout time.Duration `yaml:"graceful_shutdown_timeout"`
 	HTTPServerReadTimeout         time.Duration `yaml:"http_server_read_timeout"`


### PR DESCRIPTION
@pracucci asked me to modify https://github.com/weaveworks/common/pull/241 to make the debug log configurable instead of removing it