### PR TITLE
Revert "Add user and org labels to observed exemplars"

### DIFF
--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -68,16 +68,9 @@ func (c *HistogramCollector) After(ctx context.Context, method, statusCode strin
 // (this will always work for a HistogramVec).
 func ObserveWithExemplar(ctx context.Context, histogram prometheus.Observer, seconds float64) {
 	if traceID, ok := tracing.ExtractSampledTraceID(ctx); ok {
-		lbls := prometheus.Labels{"traceID": traceID}
-		if userID, err := user.ExtractUserID(ctx); err == nil {
-			lbls["user"] = userID
-		}
-		if orgID, err := user.ExtractOrgID(ctx); err == nil {
-			lbls["organization"] = orgID
-		}
 		histogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
 			seconds,
-			lbls,
+			prometheus.Labels{"traceID": traceID},
 		)
 		return
 	}


### PR DESCRIPTION
Reverts weaveworks/common#237

[Prometheus will panic](https://github.com/prometheus/client_golang/blob/3d482bb7cfa10c0cd0d6d3f80cf77b8ce24435bd/prometheus/value.go#L202-L237) if the total length of all labels and their values exceeds 64 runes.
This means that we can't have a user input on the exemplars labels.

