### PR TITLE
server: Expose `http` and `grpc` listen addresses.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -500,6 +500,17 @@ func (s *Server) Run() error {
 	return <-errChan
 }
 
+// HTTPListenAddr exposes `net.Addr` that `Server` is listening to for HTTP connections.
+func (s *Server) HTTPListenAddr() net.Addr {
+	return s.httpListener.Addr()
+
+}
+
+// GRPCListenAddr exposes `net.Addr` that `Server` is listening to for GRPC connections.
+func (s *Server) GRPCListenAddr() net.Addr {
+	return s.grpcListener.Addr()
+}
+
 // Stop unblocks Run().
 func (s *Server) Stop() {
 	s.handler.Stop()


### PR DESCRIPTION
The main rationale is for "choosing" random unbinded port for testing.

It's one of the Go's idiom to pass port number `0` to enforce Go's net's package to bind to some random port that is free.

example:

```
package main

import (
	"log"
	"net"
	"net/http"
	"time"

	"google.golang.org/grpc"
)

func main() {
	httpListener, err := net.Listen("tcp", "0.0.0.0:0")
	if err != nil {
		panic(err)
	}

	grpcListener, err := net.Listen("tcp", "0.0.0.0:0")
	if err != nil {
		panic(err)
	}

	h := http.Server{}
	go func() {
		log.Println("http serving at", httpListener.Addr())
		h.Serve(httpListener)
	}()

	g := grpc.Server{}
	go func() {
		log.Println("grpc serving at", grpcListener.Addr())
		g.Serve(grpcListener)
	}()

	time.Sleep(20 * time.Second)
}
```

And that will bind random "unassigned" port.

```
2022/08/08 16:51:49 grpc serving at [::]:35359
2022/08/08 16:51:49 http serving at [::]:44671
```

The problem is, currently there is no way to know what those ports are when using `server.Server`.

This PR exposes those addresses so that, we can start the test server easily and pass on the listen addresses to all it's clients.

Signed-off-by: Kaviraj <kavirajkanagaraj@gmail.com>