### PR TITLE
Fix incorrect import of obsolete github.com/go-kit/kit/log package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,37 +3,37 @@ module github.com/weaveworks/common
 go 1.14
 
 require (
-  github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
-  github.com/aws/aws-sdk-go v1.27.0
-  github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
-  github.com/davecgh/go-spew v1.1.1
-  github.com/felixge/httpsnoop v1.0.1
-  github.com/go-kit/log v0.1.0
-  github.com/gogo/googleapis v1.1.0
-  github.com/gogo/protobuf v1.3.0
-  github.com/gogo/status v1.0.3
-  github.com/golang/protobuf v1.4.3
-  github.com/gorilla/mux v1.7.3
-  github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
-  github.com/mattn/go-colorable v0.0.9 // indirect
-  github.com/mattn/go-isatty v0.0.4 // indirect
-  github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
-  github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
-  github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
-  github.com/opentracing/opentracing-go v1.1.0
-  github.com/pkg/errors v0.9.1
-  github.com/pmezard/go-difflib v1.0.0
-  github.com/prometheus/client_golang v1.11.0
-  github.com/prometheus/exporter-toolkit v0.7.0
-  github.com/sercand/kuberesolver v2.4.0+incompatible
-  github.com/sirupsen/logrus v1.6.0
-  github.com/stretchr/testify v1.4.0
-  github.com/uber/jaeger-client-go v2.28.0+incompatible
-  github.com/uber/jaeger-lib v2.2.0+incompatible
-  github.com/weaveworks/promrus v1.2.0
-  go.uber.org/atomic v1.5.1 // indirect
-  golang.org/x/net v0.0.0-20210525063256-abc453219eb5
-  golang.org/x/tools v0.0.0-20200825202427-b303f430e36d
-  google.golang.org/grpc v1.31.0
-  gopkg.in/yaml.v2 v2.4.0
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+	github.com/aws/aws-sdk-go v1.27.0
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/davecgh/go-spew v1.1.1
+	github.com/felixge/httpsnoop v1.0.1
+	github.com/go-kit/log v0.1.0
+	github.com/gogo/googleapis v1.1.0
+	github.com/gogo/protobuf v1.3.0
+	github.com/gogo/status v1.0.3
+	github.com/golang/protobuf v1.4.3
+	github.com/gorilla/mux v1.7.3
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
+	github.com/opentracing-contrib/go-grpc v0.0.0-20180928155321-4b5a12d3ff02
+	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
+	github.com/opentracing/opentracing-go v1.1.0
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/exporter-toolkit v0.7.0
+	github.com/sercand/kuberesolver v2.4.0+incompatible
+	github.com/sirupsen/logrus v1.6.0
+	github.com/stretchr/testify v1.4.0
+	github.com/uber/jaeger-client-go v2.28.0+incompatible
+	github.com/uber/jaeger-lib v2.2.0+incompatible
+	github.com/weaveworks/promrus v1.2.0
+	go.uber.org/atomic v1.5.1 // indirect
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
+	golang.org/x/tools v0.0.0-20200825202427-b303f430e36d
+	google.golang.org/grpc v1.31.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"google.golang.org/grpc"
 
 	"github.com/weaveworks/common/logging"


### PR DESCRIPTION
This removes a test dependency on `github.com/go-kit/kit/log`, which was otherwise replaced with `github.com/go-kit/log` back in #226

The `go.mod` diff was done by running `go mod tidy` - no changes except for whitespace there

Signed-off-by: Dave Henderson <dhenderson@gmail.com>