### PR TITLE
httpgrpc/server: Update NewClient to not use WithBalancerName

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sercand/kuberesolver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/balancer/roundrobin"
 
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/logging"
@@ -132,9 +131,10 @@ func NewClient(address string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	const grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
 
 	dialOptions := []grpc.DialOption{
-		grpc.WithBalancerName(roundrobin.Name),
+		grpc.WithDefaultServiceConfig(grpcServiceConfig),
 		grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),


### PR DESCRIPTION
On projects consuming this module as a library, gRPC might be set at
newer versions where the deprecated #WithBalancerName has been removed
already. Given that the version used by this module already offers a
forward-compatible method, this commit uses that instead of the
deprecated #WithBalancerName.

This is a simplified version of #240, without touching the gRPC versions.

Fixes #239

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>