### PR TITLE
Update CI build to Go 1.17; drop BUILD_IN_CONTAINER

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 # https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 defaults: &defaults
   docker:
-    - image: weaveworks/build-golang:1.14.4-stretch
+    - image: cimg/go:1.17.13
   working_directory: /go/src/github.com/weaveworks/common
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 defaults: &defaults
   docker:
     - image: cimg/go:1.17.13
-  working_directory: /go/src/github.com/weaveworks/common
+  working_directory: /home/circleci/go/src/github.com/weaveworks/common
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     - run:
         name: Lint
         command: |
-          make BUILD_IN_CONTAINER=false lint
+          make lint
 
   test:
     <<: *defaults
@@ -30,4 +30,4 @@ jobs:
     - run:
         name: Test
         command: |
-          make BUILD_IN_CONTAINER=false test
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,22 @@
-.PHONY: all test clean images
+.PHONY: all test clean
 .DEFAULT_GOAL := all
 
-# Boiler plate for bulding Docker containers.
-# All this must go at top of file I'm afraid.
-IMAGE_PREFIX := weaveworks
-IMAGE_TAG := $(shell ./tools/image-tag)
-UPTODATE := .uptodate
-BUILD_IMAGE=weaveworks/build-golang:1.14.4-stretch
-
-# Building Docker images is now automated. The convention is every directory
-# with a Dockerfile in it builds an image called weaveworks/<dirname>.
-# Dependencies (i.e. things that go in the image) still need to be explicitly
-# declared.
-%/$(UPTODATE): %/Dockerfile
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/$(shell basename $(@D)) $(@D)/
-	$(SUDO) docker tag $(IMAGE_PREFIX)/$(shell basename $(@D)) $(IMAGE_PREFIX)/$(shell basename $(@D)):$(IMAGE_TAG)
-	touch $@
-
-# Get a list of directories containing Dockerfiles
-DOCKERFILES := $(shell find . -type f -name Dockerfile ! -path "./tools/*" ! -path "./vendor/*")
-UPTODATE_FILES := $(patsubst %/Dockerfile,%/$(UPTODATE),$(DOCKERFILES))
-DOCKER_IMAGE_DIRS=$(patsubst %/Dockerfile,%,$(DOCKERFILES))
-
-all: $(UPTODATE_FILES)
+all:
 
 GENERATED_PROTOS=server/fake_server.pb.go httpgrpc/httpgrpc.pb.go middleware/middleware_test/echo_server.pb.go
 
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
-BUILD_IN_CONTAINER := true
 RM := --rm
 GO_FLAGS := -ldflags "-extldflags \"-static\" -linkmode=external -s -w" -tags netgo -i
-NETGO_CHECK = @strings $@ | grep cgo_stub\\\.go >/dev/null || { \
-	rm $@; \
-	echo "\nYour go standard library was built without the 'netgo' build tag."; \
-	echo "To fix that, run"; \
-	echo "    sudo go clean -i net"; \
-	echo "    sudo go install -tags netgo std"; \
-	false; \
-}
 
-ifeq ($(BUILD_IN_CONTAINER),true)
-
-lint test shell protos:
+protos:
 	@mkdir -p $(shell pwd)/.pkg
 	$(SUDO) docker run $(RM) -ti \
 		-v $(shell pwd)/.pkg:/go/pkg \
 		-v $(shell pwd):/go/src/github.com/weaveworks/common \
 		-e SRC_PATH=/go/src/github.com/weaveworks/common \
-		$(BUILD_IMAGE) $@
-
-else
+		$(BUILD_IMAGE) make $@
 
 protos: $(GENERATED_PROTOS)
 
@@ -58,16 +24,10 @@ protos: $(GENERATED_PROTOS)
 	protoc --go_out=plugins=grpc:../../.. $<
 
 lint:
-	./tools/lint -notestpackage -ignorespelling queriers -ignorespelling Queriers .
+	golangci-lint run --new-from-rev d2f56921e6b0
 
 test:
 	go test ./...
 
-shell:
-	bash
-
-endif
-
 clean:
 	go clean ./...
-	rm -rf $(UPTODATE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 RM := --rm
 GO_FLAGS := -ldflags "-extldflags \"-static\" -linkmode=external -s -w" -tags netgo -i
 
+# A 3-year-old image which is a reasonable match for the last time the files were generated.
+PROTOC_IMAGE=namely/protoc:1.22_1
+
 protos:
-	@mkdir -p $(shell pwd)/.pkg
-	$(SUDO) docker run $(RM) -ti \
-		-v $(shell pwd)/.pkg:/go/pkg \
-		-v $(shell pwd):/go/src/github.com/weaveworks/common \
-		-e SRC_PATH=/go/src/github.com/weaveworks/common \
-		$(BUILD_IMAGE) make $@
+	docker run $(RM) --user $(id -u):$(id -g) -v $(shell pwd):/go/src/github.com/weaveworks/common -w /go/src/github.com/weaveworks/common namely/protoc:1.22_1 --proto_path=/go/src/github.com/weaveworks/common --go_out=plugins=grpc:/go/src/ server/fake_server.proto
+	docker run $(RM) --user $(id -u):$(id -g) -v $(shell pwd):/go/src/github.com/weaveworks/common -w /go/src/github.com/weaveworks/common namely/protoc:1.22_1 --proto_path=/go/src/github.com/weaveworks/common --go_out=plugins=grpc:/go/src/ middleware/middleware_test/echo_server.proto
+	docker run $(RM) --user $(id -u):$(id -g) -v $(shell pwd):/go/src/github.com/weaveworks/common -w /go/src/github.com/weaveworks/common namely/protoc:1.22_1 --proto_path=/go/src/github.com/weaveworks/common --gogofast_out=plugins=grpc:/go/src/ httpgrpc/httpgrpc.proto
 
 protos: $(GENERATED_PROTOS)
 

--- a/httpgrpc/httpgrpc.proto
+++ b/httpgrpc/httpgrpc.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package httpgrpc;
 
-option go_package = "httpgrpc";
+option go_package = "github.com/weaveworks/common/httpgrpc";
 
 service HTTP {
   rpc Handle(HTTPRequest) returns (HTTPResponse) {};


### PR DESCRIPTION
There is no `weaveworks/build-golang` image newer than Go 1.14, and we don't really need one.
For CI, switch to using CircleCI's image, and for local builds assume the user has Go installed.

Also switch to `golangci-lint`, although I suppressed any pre-existing issues.  Can fix them in a different PR.

The one thing which is tricky to set up locally is protobuf generation, which is not used in CI.
The fact that the three `.pb.go` files in this repo were generated using two different proto commands suggests it was never done consistently.

To avoid leaving protos broken, I have used a 3rd-party image `namely/protoc:1.22_1`, which generates identical
output for two of the protos in this repo.

The third one, httpgrpc, I have not managed to match exactly, but the result is very close.
I have not updated the `.pb.go` files however. Leave that till when someone needs an update.

Also dropped a lot of boilerplate from the makefile which was not needed.