### PR TITLE
httpgrpc: reuse response body buffers

### DIFF
--- a/httpgrpc/server/stats_handler.go
+++ b/httpgrpc/server/stats_handler.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"bytes"
+	"context"
+
+	"google.golang.org/grpc/stats"
+
+	"github.com/weaveworks/common/httpgrpc"
+)
+
+const (
+	maxInPoolBufferCapacity = 1024 * 1024
+)
+
+type statsHandler struct {
+	next  stats.Handler
+	putFn func([]byte)
+}
+
+// NewStatsHandler creates a new stats.Handler that's specific to httpgrpc server.
+//
+// Rather than processing stats, the real purpose of this handler is to act as an interceptor that returns
+// httpgrpc.HTTPResponse body buffers to the pool for future reuse, once they've been serialized and sent over the wire.
+//
+// The handler is also a pass-through for other stats.Handler.
+func NewStatsHandler(next stats.Handler) stats.Handler {
+	return statsHandler{
+		next:  next,
+		putFn: putBodyBuffer,
+	}
+}
+
+func (sh statsHandler) HandleRPC(ctx context.Context, st stats.RPCStats) {
+	if sh.next != nil {
+		sh.next.HandleRPC(ctx, st)
+	}
+	outStats, ok := st.(*stats.OutPayload)
+	if !ok {
+		return
+	}
+	resp, ok := outStats.Payload.(*httpgrpc.HTTPResponse)
+	if !ok {
+		return
+	}
+	// At this point, response object has already been written to the wire,
+	// so it's safe to return its buffer back to the pool.
+	if cap(resp.Body) > maxInPoolBufferCapacity {
+		return
+	}
+	b := resp.Body[:0]
+	resp.Body = nil
+	sh.putFn(b)
+}
+
+func (sh statsHandler) TagRPC(ctx context.Context, st *stats.RPCTagInfo) context.Context {
+	if sh.next == nil {
+		return ctx
+	}
+	return sh.next.TagRPC(ctx, st)
+}
+
+func (sh statsHandler) TagConn(ctx context.Context, st *stats.ConnTagInfo) context.Context {
+	if sh.next == nil {
+		return ctx
+	}
+	return sh.next.TagConn(ctx, st)
+}
+
+func (sh statsHandler) HandleConn(ctx context.Context, st stats.ConnStats) {
+	if sh.next == nil {
+		return
+	}
+	sh.next.HandleConn(ctx, st)
+}
+
+func putBodyBuffer(b []byte) {
+	respBufferPool.Put(bytes.NewBuffer(b))
+}

--- a/httpgrpc/server/stats_handler_test.go
+++ b/httpgrpc/server/stats_handler_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/stats"
+
+	"github.com/weaveworks/common/httpgrpc"
+)
+
+func TestStatsHandler_PutBodyBuffer(t *testing.T) {
+	const bodyCapacity = 3200
+
+	var putRespBody []byte
+	sh := statsHandler{
+		putFn: func(b []byte) {
+			putRespBody = b
+		},
+	}
+
+	sh.HandleRPC(context.Background(), &stats.OutPayload{
+		Payload: &httpgrpc.HTTPResponse{
+			Body: make([]byte, 0, bodyCapacity),
+		},
+	})
+
+	require.NotNil(t, putRespBody)
+	require.Equal(t, bodyCapacity, cap(putRespBody))
+}
+
+func TestStatsHandler_DoNotPutLargeBodyBuffer(t *testing.T) {
+	var putRespBody []byte
+	sh := statsHandler{
+		putFn: func(b []byte) {
+			putRespBody = b
+		},
+	}
+
+	sh.HandleRPC(context.Background(), &stats.OutPayload{
+		Payload: &httpgrpc.HTTPResponse{
+			Body: make([]byte, 0, maxInPoolBufferCapacity+1),
+		},
+	})
+
+	require.Nil(t, putRespBody)
+}
+
+func TestStatsHandler_ForwardNext(t *testing.T) {
+	next := &mockStatsHandler{}
+
+	st := NewStatsHandler(next)
+
+	st.HandleRPC(context.Background(), &stats.OutPayload{})
+	st.TagRPC(context.Background(), &stats.RPCTagInfo{})
+	st.TagConn(context.Background(), &stats.ConnTagInfo{})
+	st.HandleConn(context.Background(), &stats.ConnBegin{})
+
+	require.True(t, next.handleRPCInvoked)
+	require.True(t, next.tagRPCInvoked)
+	require.True(t, next.tagConnInvoked)
+	require.True(t, next.handleConnInvoked)
+}
+
+type mockStatsHandler struct {
+	handleRPCInvoked  bool
+	tagRPCInvoked     bool
+	tagConnInvoked    bool
+	handleConnInvoked bool
+}
+
+func (m *mockStatsHandler) HandleRPC(_ context.Context, _ stats.RPCStats) {
+	m.handleRPCInvoked = true
+}
+
+func (m *mockStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	m.tagRPCInvoked = true
+	return ctx
+}
+
+func (m *mockStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	m.tagConnInvoked = true
+	return ctx
+}
+
+func (m *mockStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
+	m.handleConnInvoked = true
+}

--- a/server/server.go
+++ b/server/server.go
@@ -367,8 +367,13 @@ func New(cfg Config) (*Server, error) {
 		grpc.MaxRecvMsgSize(cfg.GPRCServerMaxRecvMsgSize),
 		grpc.MaxSendMsgSize(cfg.GRPCServerMaxSendMsgSize),
 		grpc.MaxConcurrentStreams(uint32(cfg.GPRCServerMaxConcurrentStreams)),
-		grpc.StatsHandler(middleware.NewStatsHandler(receivedMessageSize, sentMessageSize, inflightRequests)),
 	}
+
+	// Set server stats handler.
+	grpcOptions = append(grpcOptions, grpc.StatsHandler(httpgrpc_server.NewStatsHandler(
+		middleware.NewStatsHandler(receivedMessageSize, sentMessageSize, inflightRequests),
+	)))
+
 	grpcOptions = append(grpcOptions, cfg.GRPCOptions...)
 	if grpcTLSConfig != nil {
 		grpcCreds := credentials.NewTLS(grpcTLSConfig)


### PR DESCRIPTION
Signed-off-by: Miguel Ángel Ortuño <ortuman@gmail.com>

This PR adapts `httpgrpc` server to recycle recording buffers after they've been used for copying HTTP responses, aiming to reduce GC pressure. 

To safely return body buffers back to the pool, we resorted to gRPC `stats.Handler` to determine whether responses have been effectively serialized and sent over the wire.

An extra benchmark named `BenchmarkServer_ServeHTTP` has been included as part of this PR to test the change. 

Comparision:

```
name                                   old time/op    new time/op    delta
Server_ServeHTTP/1k_response_size-8      43.8µs ± 0%    44.5µs ± 0%   +1.54%  (p=0.000 n=9+10)
Server_ServeHTTP/10k_response_size-8     53.2µs ± 0%    52.6µs ± 0%   -1.10%  (p=0.000 n=8+8)
Server_ServeHTTP/100k_response_size-8     117µs ±24%     107µs ±23%     ~     (p=0.113 n=10+9)
Server_ServeHTTP/256k_response_size-8     234µs ±31%     207µs ±23%     ~     (p=0.105 n=10+10)
Server_ServeHTTP/512k_response_size-8     412µs ±31%     347µs ±15%  -15.77%  (p=0.015 n=10+10)
Server_ServeHTTP/1M_response_size-8       751µs ±15%     669µs ±10%     ~     (p=0.089 n=10+10)
Server_ServeHTTP/10M_response_size-8     2.02ms ± 1%    2.02ms ± 1%     ~     (p=0.481 n=10+10)

name                                   old alloc/op   new alloc/op   delta
Server_ServeHTTP/1k_response_size-8      19.1kB ± 0%    19.3kB ± 0%   +0.81%  (p=0.000 n=8+9)
Server_ServeHTTP/10k_response_size-8     84.5kB ± 0%    75.1kB ± 0%  -11.21%  (p=0.000 n=9+8)
Server_ServeHTTP/100k_response_size-8     724kB ± 1%     630kB ±18%  -12.92%  (p=0.003 n=8+10)
Server_ServeHTTP/256k_response_size-8    1.90MB ±11%    1.57MB ±12%  -17.47%  (p=0.000 n=10+10)
Server_ServeHTTP/512k_response_size-8    3.58MB ± 6%    2.89MB ± 7%  -19.19%  (p=0.000 n=9+10)
Server_ServeHTTP/1M_response_size-8      6.56MB ± 1%    5.44MB ± 2%  -17.08%  (p=0.000 n=10+10)
Server_ServeHTTP/10M_response_size-8     21.2MB ± 0%    21.2MB ± 0%     ~     (p=0.573 n=8+10)

name                                   old allocs/op  new allocs/op  delta
Server_ServeHTTP/1k_response_size-8         213 ± 0%       229 ± 0%   +7.51%  (p=0.000 n=10+10)
Server_ServeHTTP/10k_response_size-8        213 ± 0%       229 ± 0%   +7.51%  (p=0.000 n=10+10)
Server_ServeHTTP/100k_response_size-8       227 ± 0%       243 ± 0%   +7.05%  (p=0.000 n=10+10)
Server_ServeHTTP/256k_response_size-8       242 ± 0%       255 ± 3%   +5.39%  (p=0.000 n=9+10)
Server_ServeHTTP/512k_response_size-8       244 ± 3%       262 ± 2%   +7.58%  (p=0.000 n=10+10)
Server_ServeHTTP/1M_response_size-8         266 ± 4%       284 ± 1%   +6.65%  (p=0.000 n=10+10)
Server_ServeHTTP/10M_response_size-8        294 ± 1%       312 ± 0%   +5.94%  (p=0.000 n=10+10)
```

Here I attach the full benchmark results for the [old](https://gist.github.com/ortuman/7b88dd72fd218299c07ae730cdb0ad0b) and the [new](https://gist.github.com/ortuman/a6b537b038e524fc706451ba771cd5d2) implementations.  