### PR TITLE
Make gRPC connection timeout configurable

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -538,6 +538,7 @@ func TestTLSServer(t *testing.T) {
 		GRPCListenAddress: "localhost",
 		GRPCListenPort:    9194,
 	}
+	cfg.GRPCServerConnectionTimeout = time.Second
 	server, err := New(cfg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
In the upstream project loki（https://github.com/grafana/loki/）, we encountered a grpc timeout of 120s, and it could not be fixed by loki. 
We checked that the timeout of grpc 120s was configured here in common.

`defaultServerOptions.connectionTimeout:120 * time.Second,
`

```
    server:
      http_listen_port: 3100
      grpc_listen_port: 9095
      http_server_read_timeout: 600s
      http_server_write_timeout: 600s
      http_server_idle_timeout: 600s
```

This config interrupts loki's query, and loki's other timeouts are set to 5 minutes, but at 2 minutes, loki cancels.

We need to make this config modifiable to adapt to the brute force scan mode logging system of loki

```

level=info ts=2022-10-17T06:28:23.653973829Z caller=handler.go:174 org_id=fake msg="slow query detected" method=GET host=loki-loki-distributed-query-frontend.loki-research-x4.svc.cluster.local:3100 path=/loki/api/v1/query_range time_taken=2m1.965813572s param_direction=backward param_end=1665987976954000000 param_limit=1000 param_query="{evtType=\"evt_ttsd\"} | json" param_start=1665966376954000000 param_step=10000ms
level=warn ts=2022-10-17T06:28:23.654024222Z caller=logging.go:86 traceID=55bbc9c1308e9842 orgID=fake msg="GET /loki/api/v1/query_range?direction=backward&end=1665987976954000000&limit=1000&query=%7BevtType%3D%22evt_ttsd%22%7D+%7C+json&start=1665966376954000000&step=10000ms (500) 2m1.9659356s Response: \"query index: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing dial tcp 10.100.190.157:9095: i/o timeout\\\"\\n\" ws: false; Accept-Encoding: gzip; Connection: close; User-Agent: Grafana/9.1.5; "

level=error ts=2022-10-17T06:28:23.654071531Z caller=retry.go:73 org_id=fake msg="error processing request" try=0 err="rpc error: code = Code(500) desc = query index: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 10.100.190.157:9095: i/o timeout\"\n"

and keeps repeating the timeout issue. 
```