### PR TITLE
Lint cleanup

### DIFF
--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sercand/kuberesolver"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/logging"
@@ -129,7 +130,7 @@ func NewClient(address string) (*Client, error) {
 
 	dialOptions := []grpc.DialOption{
 		grpc.WithDefaultServiceConfig(grpcServiceConfig),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithChainUnaryInterceptor(
 			otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer()),
 			middleware.ClientUserHeaderInterceptor,

--- a/httpgrpc/server/server.go
+++ b/httpgrpc/server/server.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync"
 
 	otgrpc "github.com/opentracing-contrib/go-grpc"
 	"github.com/opentracing/opentracing-go"
@@ -70,12 +69,8 @@ func (s Server) Handle(ctx context.Context, r *httpgrpc.HTTPRequest) (*httpgrpc.
 
 // Client is a http.Handler that forwards the request over gRPC.
 type Client struct {
-	mtx       sync.RWMutex
-	service   string
-	namespace string
-	port      string
-	client    httpgrpc.HTTPClient
-	conn      *grpc.ClientConn
+	client httpgrpc.HTTPClient
+	conn   *grpc.ClientConn
 }
 
 // ParseURL deals with direct:// style URLs, as well as kubernetes:// urls.

--- a/httpgrpc/server/server_test.go
+++ b/httpgrpc/server/server_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -92,19 +91,21 @@ func TestParseURL(t *testing.T) {
 	for _, tc := range []struct {
 		input    string
 		expected string
-		err      error
+		err      string
 	}{
-		{"direct://foo", "foo", nil},
-		{"kubernetes://foo:123", "kubernetes:///foo:123", nil},
-		{"querier.cortex:995", "kubernetes:///querier.cortex:995", nil},
-		{"foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", nil},
-		{"kubernetes:///foo:123", "kubernetes:///foo:123", nil},
-		{"dns:///foo.bar.svc.local:995", "dns:///foo.bar.svc.local:995", nil},
-		{"monster://foo:995", "", fmt.Errorf("unrecognised scheme: monster")},
+		{"direct://foo", "foo", ""},
+		{"kubernetes://foo:123", "kubernetes:///foo:123", ""},
+		{"querier.cortex:995", "kubernetes:///querier.cortex:995", ""},
+		{"foo.bar.svc.local:995", "kubernetes:///foo.bar.svc.local:995", ""},
+		{"kubernetes:///foo:123", "kubernetes:///foo:123", ""},
+		{"dns:///foo.bar.svc.local:995", "dns:///foo.bar.svc.local:995", ""},
+		{"monster://foo:995", "", "unrecognised scheme: monster"},
 	} {
 		got, err := ParseURL(tc.input)
-		if !reflect.DeepEqual(tc.err, err) {
-			t.Fatalf("Got: %v, expected: %v", err, tc.err)
+		if tc.err == "" {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, tc.err)
 		}
 		assert.Equal(t, tc.expected, got)
 	}

--- a/middleware/grpc_stats_test.go
+++ b/middleware/grpc_stats_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -57,7 +58,7 @@ func TestGrpcStats(t *testing.T) {
 	grpc_health_v1.RegisterHealthServer(serv, health.NewServer())
 
 	closed := false
-	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure())
+	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer func() {
 		if !closed {
@@ -150,7 +151,7 @@ func TestGrpcStatsStreaming(t *testing.T) {
 
 	middleware_test.RegisterEchoServerServer(serv, &halfEcho{log: t.Log})
 
-	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10e6), grpc.MaxCallSendMsgSize(10e6)))
+	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10e6), grpc.MaxCallSendMsgSize(10e6)))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, conn.Close())

--- a/middleware/response_test.go
+++ b/middleware/response_test.go
@@ -34,7 +34,7 @@ func TestBadResponseLoggingWriter(t *testing.T) {
 		if wrapped.getStatusCode() != tc.statusCode {
 			t.Errorf("Wrong status code: have %d want %d", wrapped.getStatusCode(), tc.statusCode)
 		}
-		data := string(buf.Bytes())
+		data := buf.String()
 		if data != tc.expected {
 			t.Errorf("Wrong data: have %q want %q", data, tc.expected)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -413,7 +413,7 @@ func New(cfg Config) (*Server, error) {
 			InflightRequests: inflightRequests,
 		},
 	}
-	httpMiddleware := []middleware.Interface{}
+	var httpMiddleware []middleware.Interface
 	if cfg.DoNotAddDefaultHTTPMiddleware {
 		httpMiddleware = cfg.HTTPMiddleware
 	} else {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
@@ -128,7 +129,7 @@ func TestDefaultAddresses(t *testing.T) {
 	go server.Run()
 	defer server.Shutdown()
 
-	conn, err := grpc.Dial("localhost:9095", grpc.WithInsecure())
+	conn, err := grpc.Dial("localhost:9095", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer conn.Close()
 	require.NoError(t, err)
 
@@ -169,7 +170,7 @@ func TestErrorInstrumentationMiddleware(t *testing.T) {
 
 	go server.Run()
 
-	conn, err := grpc.Dial("localhost:1234", grpc.WithInsecure())
+	conn, err := grpc.Dial("localhost:1234", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	defer conn.Close()
 	require.NoError(t, err)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -507,7 +507,8 @@ func TestMiddlewareLogging(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://127.0.0.1:9192/error500", nil)
 	require.NoError(t, err)
-	http.DefaultClient.Do(req)
+	_, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
 }
 
 func TestTLSServer(t *testing.T) {
@@ -651,7 +652,8 @@ func TestLogSourceIPs(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "http://127.0.0.1:9195/error500", nil)
 	require.NoError(t, err)
-	http.DefaultClient.Do(req)
+	_, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
 
 	require.Equal(t, fake.sourceIPs, "127.0.0.1")
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -130,8 +130,8 @@ func TestDefaultAddresses(t *testing.T) {
 	defer server.Shutdown()
 
 	conn, err := grpc.Dial("localhost:9095", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	defer conn.Close()
 	require.NoError(t, err)
+	defer conn.Close()
 
 	empty := google_protobuf.Empty{}
 	client := NewFakeServerClient(conn)
@@ -171,8 +171,8 @@ func TestErrorInstrumentationMiddleware(t *testing.T) {
 	go server.Run()
 
 	conn, err := grpc.Dial("localhost:1234", grpc.WithTransportCredentials(insecure.NewCredentials()))
-	defer conn.Close()
 	require.NoError(t, err)
+	defer conn.Close()
 
 	empty := google_protobuf.Empty{}
 	client := NewFakeServerClient(conn)
@@ -584,8 +584,8 @@ func TestTLSServer(t *testing.T) {
 	require.Equal(t, expected, body)
 
 	conn, err := grpc.Dial("localhost:9194", grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-	defer conn.Close()
 	require.NoError(t, err)
+	defer conn.Close()
 
 	empty := google_protobuf.Empty{}
 	grpcClient := NewFakeServerClient(conn)

--- a/tools/runner/runner.go
+++ b/tools/runner/runner.go
@@ -107,7 +107,7 @@ func (t test) run(hosts []string) bool {
 		err = fmt.Errorf("timed out")
 	}
 
-	duration := float64(time.Now().Sub(start)) / float64(time.Second)
+	duration := float64(time.Since(start)) / float64(time.Second)
 
 	consoleLock.Lock()
 	if err != nil {


### PR DESCRIPTION
See individual commits for details.

Should be no change in behaviour, just replacing some deprecated or questionable code.

This does not address every warning from golangci-lint, but it's a step forward.
