### PR TITLE
Log middleware now accepts a list of headers to exclude

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // anonymous import to get the pprof handler registered
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -101,13 +102,15 @@ type Config struct {
 	GRPCServerMinTimeBetweenPings      time.Duration `yaml:"grpc_server_min_time_between_pings"`
 	GRPCServerPingWithoutStreamAllowed bool          `yaml:"grpc_server_ping_without_stream_allowed"`
 
-	LogFormat             logging.Format    `yaml:"log_format"`
-	LogLevel              logging.Level     `yaml:"log_level"`
-	Log                   logging.Interface `yaml:"-"`
-	LogSourceIPs          bool              `yaml:"log_source_ips_enabled"`
-	LogSourceIPsHeader    string            `yaml:"log_source_ips_header"`
-	LogSourceIPsRegex     string            `yaml:"log_source_ips_regex"`
-	LogRequestAtInfoLevel bool              `yaml:"log_request_at_info_level_enabled"`
+	LogFormat                    logging.Format    `yaml:"log_format"`
+	LogLevel                     logging.Level     `yaml:"log_level"`
+	Log                          logging.Interface `yaml:"-"`
+	LogSourceIPs                 bool              `yaml:"log_source_ips_enabled"`
+	LogSourceIPsHeader           string            `yaml:"log_source_ips_header"`
+	LogSourceIPsRegex            string            `yaml:"log_source_ips_regex"`
+	LogRequestHeaders            bool              `yaml:"log_request_headers"`
+	LogRequestAtInfoLevel        bool              `yaml:"log_request_at_info_level_enabled"`
+	LogRequestExcludeHeadersList string            `yaml:"log_request_exclude_headers_list"`
 
 	// If not set, default signal handler is used.
 	SignalHandler SignalHandler `yaml:"-"`
@@ -400,11 +403,7 @@ func New(cfg Config) (*Server, error) {
 			RouteMatcher: router,
 			SourceIPs:    sourceIPs,
 		},
-		middleware.Log{
-			Log:                   log,
-			SourceIPs:             sourceIPs,
-			LogRequestAtInfoLevel: cfg.LogRequestAtInfoLevel,
-		},
+		middleware.NewLogMiddleware(log, cfg.LogRequestHeaders, cfg.LogRequestAtInfoLevel, sourceIPs, strings.Split(cfg.LogRequestExcludeHeadersList, ",")),
 		middleware.Instrument{
 			RouteMatcher:     router,
 			Duration:         requestDuration,


### PR DESCRIPTION
Previously the log middleware would exclude printing only the headers "Cookie", "Authorization" and "X-Csrf-Token". I believe the users of this library may want to ommit more headers than those.

To do so I've changed how the middleware is initialize to optionally add more headers to the list.

Also I've added a unit test to make sure the behavior works as expected.

Also I've added an optional configuration parameter to the server to set LogRequestHeaders from there. This parameter was already an option in the log middleware but was not exposed in the server.

Signed-off-by: Jesus Vazquez <jesus.vazquez@grafana.com>