### PR TITLE
Add Unwrap method to http.ResponseWriter implementations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.27.0
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/felixge/httpsnoop v1.0.1
+	github.com/felixge/httpsnoop v1.0.3
 	github.com/go-kit/log v0.2.1
 	github.com/gogo/googleapis v1.1.0
 	github.com/gogo/protobuf v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,6 @@ github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
-github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,8 @@ github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/middleware/errorhandler.go
+++ b/middleware/errorhandler.go
@@ -51,6 +51,11 @@ func newErrorInterceptor(w http.ResponseWriter, code int) *errorInterceptor {
 	return &i
 }
 
+// Unwrap method is used by http.ResponseController to get access to original http.ResponseWriter.
+func (i *errorInterceptor) Unwrap() http.ResponseWriter {
+	return i.originalWriter
+}
+
 // Header implements http.ResponseWriter
 func (i *errorInterceptor) Header() http.Header {
 	return i.headers

--- a/middleware/response.go
+++ b/middleware/response.go
@@ -52,6 +52,11 @@ func newBadResponseLoggingWriter(rw http.ResponseWriter, buffer io.Writer) badRe
 	return &b
 }
 
+// Unwrap method is used by http.ResponseController to get access to original http.ResponseWriter.
+func (b *nonFlushingBadResponseLoggingWriter) Unwrap() http.ResponseWriter {
+	return b.rw
+}
+
 // Header returns the header map that will be sent by WriteHeader.
 // Implements ResponseWriter.
 func (b *nonFlushingBadResponseLoggingWriter) Header() http.Header {

--- a/middleware/response_test.go
+++ b/middleware/response_test.go
@@ -78,3 +78,13 @@ func TestBadResponseLoggingWriter_WithAndWithoutFlusher(t *testing.T) {
 		t.Errorf("Flush should have worked but did not")
 	}
 }
+
+type responseWriterWithUnwrap interface {
+	http.ResponseWriter
+	Unwrap() http.ResponseWriter
+}
+
+// Verify that custom http.ResponseWriter implementations implement Unwrap() method, used by http.ResponseContoller.
+var _ responseWriterWithUnwrap = &nonFlushingBadResponseLoggingWriter{}
+var _ responseWriterWithUnwrap = &flushingBadResponseLoggingWriter{}
+var _ responseWriterWithUnwrap = &errorInterceptor{}


### PR DESCRIPTION
This PR adds `Unwrap` method to all implementations of `http.ResponseWriter`.

New https://pkg.go.dev/net/http#ResponseController introduced in Go 1.20 uses `Unwrap` method to get access to original `http.ResponseWriter` or underlying connection.

My use case: I'd like to use `http.ResponseController` to set longer timeouts on HTTP endpoints for uploading big files, overriding global `-server.http-write-timeout` and `-server.http-read-timeout`. 

This PR also updates httpsnoop library to version 1.0.3, which supports `Unwrap` method as well (since 1.0.2) (https://github.com/felixge/httpsnoop/issues/8).

(To make weaveworks/common fully compatible with new `http.ResponseController`, `opentracing-contrib/go-stdlib` library needs an update too, after https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged).