### PR TITLE
middleware: add a way to stop errors being logged

### DIFF
--- a/middleware/grpc_logging.go
+++ b/middleware/grpc_logging.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"time"
 
 	"golang.org/x/net/context"
@@ -30,6 +31,9 @@ func (s GRPCServerLog) UnaryServerInterceptor(ctx context.Context, req interface
 	resp, err := handler(ctx, req)
 	if err == nil && s.DisableRequestSuccessLog {
 		return resp, nil
+	}
+	if errors.Is(err, DoNotLogError{}) {
+		return resp, err
 	}
 
 	entry := user.LogWith(ctx, s.Log).WithFields(logging.Fields{"method": info.FullMethod, "duration": time.Since(begin)})

--- a/middleware/grpc_logging_test.go
+++ b/middleware/grpc_logging_test.go
@@ -1,11 +1,14 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/weaveworks/common/logging"
@@ -26,5 +29,46 @@ func BenchmarkGRPCServerLog_UnaryServerInterceptor_NoError(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		_, _ = l.UnaryServerInterceptor(ctx, nil, info, handler)
+	}
+}
+
+func TestGrpcLogging(t *testing.T) {
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: "Test"}
+	for _, tc := range []struct {
+		err         error
+		logContains []string
+	}{{
+		err:         context.Canceled,
+		logContains: []string{"level=debug", "context canceled"},
+	}, {
+		err:         errors.New("yolo"),
+		logContains: []string{"level=warn", "err=yolo"},
+	}, {
+		err:         nil,
+		logContains: []string{"level=debug", "method=Test"},
+	}, {
+		err:         DoNotLogError{Err: errors.New("yolo")},
+		logContains: nil,
+	}} {
+		t.Run("", func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			logger := logging.GoKit(log.NewLogfmtLogger(buf))
+			l := GRPCServerLog{Log: logger, WithRequest: true, DisableRequestSuccessLog: false}
+
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, tc.err
+			}
+
+			_, err := l.UnaryServerInterceptor(ctx, nil, info, handler)
+			require.ErrorIs(t, tc.err, err)
+
+			if len(tc.logContains) == 0 {
+				require.Empty(t, buf)
+			}
+			for _, content := range tc.logContains {
+				require.Contains(t, buf.String(), content)
+			}
+		})
 	}
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -51,7 +51,7 @@ func NewLogMiddleware(log logging.Interface, logRequestHeaders bool, logRequestA
 type DoNotLogError struct{ Err error }
 
 func (i DoNotLogError) Error() string        { return i.Err.Error() }
-func Unwrap(i DoNotLogError) error           { return i.Err }
+func (i DoNotLogError) Unwrap() error        { return i.Err }
 func (i DoNotLogError) Is(target error) bool { _, ok := target.(DoNotLogError); return ok }
 
 // logWithRequest information from the request and context as fields.

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -46,6 +46,14 @@ func NewLogMiddleware(log logging.Interface, logRequestHeaders bool, logRequestA
 	}
 }
 
+// This can be used with `errors.Is` to see if the error marked itself as not to be logged.
+// E.g. if the error is caused by overload, then we don't want to log it because that uses more resource.
+type DoNotLogError struct{ Err error }
+
+func (i DoNotLogError) Error() string        { return i.Err.Error() }
+func Unwrap(i DoNotLogError) error           { return i.Err }
+func (i DoNotLogError) Is(target error) bool { _, ok := target.(DoNotLogError); return ok }
+
 // logWithRequest information from the request and context as fields.
 func (l Log) logWithRequest(r *http.Request) logging.Interface {
 	localLog := l.Log
@@ -83,6 +91,9 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 		statusCode, writeErr := wrapped.getStatusCode(), wrapped.getWriteError()
 
 		if writeErr != nil {
+			if errors.Is(writeErr, DoNotLogError{}) {
+				return
+			}
 			if errors.Is(writeErr, context.Canceled) {
 				if l.LogRequestAtInfoLevel {
 					requestLog.Infof("%s %s %s, request cancelled: %s ws: %v; %s", r.Method, uri, time.Since(begin), writeErr, IsWSHandshakeRequest(r), headers)

--- a/middleware/logging_test.go
+++ b/middleware/logging_test.go
@@ -28,6 +28,9 @@ func TestBadWriteLogging(t *testing.T) {
 	}, {
 		err:         nil,
 		logContains: []string{"debug", "GET http://example.com/foo (200)"},
+	}, {
+		err:         DoNotLogError{Err: errors.New("yolo")},
+		logContains: nil,
 	}} {
 		buf := bytes.NewBuffer(nil)
 		logrusLogger := logrus.New()
@@ -51,6 +54,9 @@ func TestBadWriteLogging(t *testing.T) {
 		}
 		loggingHandler.ServeHTTP(w, req)
 
+		if len(tc.logContains) == 0 {
+			require.Empty(t, buf)
+		}
 		for _, content := range tc.logContains {
 			require.True(t, bytes.Contains(buf.Bytes(), []byte(content)))
 		}


### PR DESCRIPTION
E.g. if the error is caused by overload, then we don't want to log it because that uses more resource.