### PR TITLE
Fix issue where successful streaming requests are not always captured in metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,15 +23,16 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.14.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/prometheus/exporter-toolkit v0.8.2
 	github.com/sercand/kuberesolver/v4 v4.0.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.8.1
 	github.com/uber/jaeger-client-go v2.28.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/weaveworks/promrus v1.2.0
-	go.uber.org/atomic v1.5.1 // indirect
+	go.uber.org/atomic v1.5.1
 	golang.org/x/net v0.5.0
 	golang.org/x/tools v0.3.0
 	google.golang.org/grpc v1.53.0

--- a/middleware/grpc_instrumentation_test.go
+++ b/middleware/grpc_instrumentation_test.go
@@ -1,13 +1,25 @@
 package middleware
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"github.com/weaveworks/common/httpgrpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/weaveworks/common/httpgrpc"
 )
 
 func TestErrorCode_NoError(t *testing.T) {
@@ -37,4 +49,262 @@ func TestErrorCode_Unknown(t *testing.T) {
 	err := status.Errorf(codes.Unknown, "Fail")
 	a := errorCode(err)
 	assert.Equal(t, "error", a)
+}
+
+func setUpStreamClientInstrumentInterceptorTest(t *testing.T, serverStreams bool) (grpc.ClientStream, *mockGrpcStream, context.CancelFunc, *prometheus.Registry) {
+	reg := prometheus.NewPedanticRegistry()
+	metric := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "client_request_duration_seconds",
+	}, []string{"method", "result"})
+	require.NoError(t, reg.Register(metric))
+
+	interceptor := StreamClientInstrumentInterceptor(metric)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	t.Cleanup(cancelCtx)
+
+	mockStream := &mockGrpcStream{}
+	streamer := func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return mockStream, nil
+	}
+	desc := &grpc.StreamDesc{ServerStreams: serverStreams}
+	stream, err := interceptor(ctx, desc, nil, "/thing.Server/DoThing", streamer)
+	require.NoError(t, err)
+
+	return stream, mockStream, cancelCtx, reg
+}
+
+func TestStreamClientInstrumentInterceptor_SendMsg(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	err := stream.SendMsg("message 1")
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.sendMsgError = errors.New("something went wrong")
+	err = stream.SendMsg("message 2")
+	require.Equal(t, mockStream.sendMsgError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_RecvMsg(t *testing.T) {
+	t.Run("server is streaming", func(t *testing.T) {
+		t.Run("RecvMsg returns an EOF", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireNoRequestMetrics(t, reg)
+
+			mockStream.recvMsgError = io.EOF
+			err = stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "2xx", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "2xx")
+		})
+
+		t.Run("RecvMsg returns an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireNoRequestMetrics(t, reg)
+
+			mockStream.recvMsgError = errors.New("something went wrong")
+			err = stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "error", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+		})
+	})
+
+	t.Run("server is unary", func(t *testing.T) {
+		t.Run("RecvMsg does not return an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, false)
+
+			err := stream.RecvMsg(nil)
+			require.NoError(t, err)
+			requireRequestMetrics(t, reg, "2xx", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "2xx")
+		})
+
+		t.Run("RecvMsg returns an error", func(t *testing.T) {
+			stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, false)
+
+			mockStream.recvMsgError = errors.New("something went wrong")
+			err := stream.RecvMsg(nil)
+			require.Equal(t, mockStream.recvMsgError, err)
+			requireRequestMetrics(t, reg, "error", 1)
+
+			requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+		})
+	})
+}
+
+func TestStreamClientInstrumentInterceptor_Header(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	_, err := stream.Header()
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.headerError = errors.New("something went wrong")
+	_, err = stream.Header()
+	require.Equal(t, mockStream.headerError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_CloseSend(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	err := stream.CloseSend()
+	require.NoError(t, err)
+	requireNoRequestMetrics(t, reg)
+
+	mockStream.closeSendError = errors.New("something went wrong")
+	err = stream.CloseSend()
+	require.Equal(t, mockStream.closeSendError, err)
+	requireRequestMetrics(t, reg, "error", 1)
+
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "error")
+}
+
+func TestStreamClientInstrumentInterceptor_ContextCancelled(t *testing.T) {
+	stream, mockStream, cancelCtx, reg := setUpStreamClientInstrumentInterceptorTest(t, true)
+
+	cancelCtx()
+
+	require.Eventually(t, func() bool {
+		return gatherRequestMetrics(t, reg) != ""
+	}, time.Second, 10*time.Millisecond, "gave up waiting for the context cancellation to report metrics")
+
+	requireRequestMetrics(t, reg, "cancel", 1)
+	requireDoesNotIncrementMetricsAfterCompletion(t, stream, mockStream, cancelCtx, reg, "cancel")
+}
+
+func requireDoesNotIncrementMetricsAfterCompletion(t *testing.T, stream grpc.ClientStream, mockStream *mockGrpcStream, cancelCtx context.CancelFunc, reg *prometheus.Registry, result string) {
+	// Should not increment metric, even if Header now returns an error.
+	mockStream.headerError = errors.New("calling Header() failed")
+	_, err := stream.Header()
+	require.Equal(t, mockStream.headerError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if SendMsg now returns an error
+	mockStream.sendMsgError = errors.New("calling SendMsg() failed")
+	err = stream.SendMsg("one last message")
+	require.Equal(t, mockStream.sendMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if RecvMsg now returns an error
+	mockStream.recvMsgError = errors.New("calling RecvMsg() failed")
+	err = stream.RecvMsg(nil)
+	require.Equal(t, mockStream.recvMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if RecvMsg now returns EOF
+	mockStream.recvMsgError = io.EOF
+	err = stream.RecvMsg(nil)
+	require.Equal(t, mockStream.recvMsgError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if CloseSend now returns an error
+	mockStream.closeSendError = errors.New("calling CloseSend() failed")
+	err = stream.CloseSend()
+	require.Equal(t, mockStream.closeSendError, err)
+	requireRequestMetrics(t, reg, result, 1)
+
+	// Should not increment metric, even if the context is cancelled
+	cancelCtx()
+	requireRequestMetrics(t, reg, result, 1)
+}
+
+func requireNoRequestMetrics(t *testing.T, g prometheus.Gatherer) {
+	actual := gatherRequestMetrics(t, g)
+	require.Empty(t, actual, "expected no request metrics to be reported")
+}
+
+func requireRequestMetrics(t *testing.T, g prometheus.Gatherer, result string, count int) {
+	expected := fmt.Sprintf(`client_request_duration_seconds_count{method="/thing.Server/DoThing", result="%v"} %v`, result, count)
+	actual := gatherRequestMetrics(t, g)
+
+	require.Equalf(t, expected, actual, "expected count of %v for requests with result '%v'", count, result)
+}
+
+func gatherRequestMetrics(t *testing.T, g prometheus.Gatherer) string {
+	got, err := g.Gather()
+	require.NoError(t, err)
+
+	actual := ""
+
+	for _, mf := range got {
+		require.Equal(t, "client_request_duration_seconds", *mf.Name)
+
+		for _, m := range mf.Metric {
+			require.NotNil(t, m.Histogram)
+			actual += fmt.Sprintf(`%v_count%v %v`, *mf.Name, formatLabelPairs(m.Label), *m.Histogram.SampleCount)
+		}
+	}
+
+	return actual
+}
+
+func formatLabelPairs(pairs []*io_prometheus_client.LabelPair) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+
+	b := strings.Builder{}
+	b.WriteString("{")
+
+	for i, p := range pairs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+
+		b.WriteString(*p.Name)
+		b.WriteString(`="`)
+		b.WriteString(*p.Value)
+		b.WriteString(`"`)
+	}
+
+	b.WriteString("}")
+
+	return b.String()
+}
+
+type mockGrpcStream struct {
+	recvMsgError   error
+	sendMsgError   error
+	headerError    error
+	closeSendError error
+}
+
+func (m *mockGrpcStream) Header() (metadata.MD, error) {
+	return nil, m.headerError
+}
+
+func (m *mockGrpcStream) Trailer() metadata.MD {
+	return nil
+}
+
+func (m *mockGrpcStream) CloseSend() error {
+	return m.closeSendError
+}
+
+func (m *mockGrpcStream) Context() context.Context {
+	return nil
+}
+
+func (m *mockGrpcStream) SendMsg(interface{}) error {
+	return m.sendMsgError
+}
+
+func (m *mockGrpcStream) RecvMsg(interface{}) error {
+	return m.recvMsgError
 }


### PR DESCRIPTION
According to https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream, it's safe to not call `Recv()` on a `grpc.ClientStream` until it's exhausted if you clean up the stream in other ways:

> To ensure resources are not leaked due to the stream returned, one of the following actions must be performed:
> 
> 1. Call Close on the ClientConn.
> 2. Cancel the context provided.
> 3. Call RecvMsg until a non-nil error is returned. A protobuf-generated client-streaming RPC, for instance, might use the helper function CloseAndRecv (note that CloseSend does not Recv, therefore is not guaranteed to release all resources).
> 4. Receive a non-nil, non-io.EOF error from Header or SendMsg.

However, the current implementation of `instrumentedClientStream` does not correctly handle choices 1 and 2: if the `ClientConn` is closed and no further action is taken with the stream, or if the context provided is cancelled, metrics for the request are not recorded.

This PR addresses this issue for choice 2 (context cancellation). The fix is inspired by `opentracing-contrib/go-grpc`'s equivalent implementation: [source](https://github.com/opentracing-contrib/go-grpc/blob/master/client.go)

Fixing the issue for choice 1 (calling `Close` on `ClientConn`) is more involved, so in the interests of keeping this PR small, I've chosen to focus on just the context cancellation case here.