### PR TITLE
Server: use consistent names for metrics

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -10,9 +10,9 @@ import (
 type Metrics struct {
 	TcpConnections      *prometheus.GaugeVec
 	TcpConnectionsLimit *prometheus.GaugeVec
-	RequestDuration     *prometheus.HistogramVec
-	ReceivedMessageSize *prometheus.HistogramVec
-	SentMessageSize     *prometheus.HistogramVec
+	Duration            *prometheus.HistogramVec
+	RequestBodySize     *prometheus.HistogramVec
+	ResponseBodySize    *prometheus.HistogramVec
 	InflightRequests    *prometheus.GaugeVec
 }
 
@@ -28,7 +28,7 @@ func NewServerMetrics(cfg Config) *Metrics {
 			Name:      "tcp_connections_limit",
 			Help:      "The max number of TCP connections that can be accepted (0 means no limit).",
 		}, []string{"protocol"}),
-		RequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:                       cfg.MetricsNamespace,
 			Name:                            "request_duration_seconds",
 			Help:                            "Time (in seconds) spent serving HTTP requests.",
@@ -37,13 +37,13 @@ func NewServerMetrics(cfg Config) *Metrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"method", "route", "status_code", "ws"}),
-		ReceivedMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		RequestBodySize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "request_message_bytes",
 			Help:      "Size (in bytes) of messages received in the request.",
 			Buckets:   middleware.BodySizeBuckets,
 		}, []string{"method", "route"}),
-		SentMessageSize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		ResponseBodySize: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.MetricsNamespace,
 			Name:      "response_message_bytes",
 			Help:      "Size (in bytes) of messages sent in response.",
@@ -61,9 +61,9 @@ func (s *Metrics) MustRegister(registerer prometheus.Registerer) {
 	registerer.MustRegister(
 		s.TcpConnections,
 		s.TcpConnectionsLimit,
-		s.RequestDuration,
-		s.ReceivedMessageSize,
-		s.SentMessageSize,
+		s.Duration,
+		s.RequestBodySize,
+		s.ResponseBodySize,
 		s.InflightRequests,
 	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -327,14 +327,14 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 	grpcMiddleware := []grpc.UnaryServerInterceptor{
 		serverLog.UnaryServerInterceptor,
 		otgrpc.OpenTracingServerInterceptor(opentracing.GlobalTracer()),
-		middleware.UnaryServerInstrumentInterceptor(metrics.RequestDuration),
+		middleware.UnaryServerInstrumentInterceptor(metrics.Duration),
 	}
 	grpcMiddleware = append(grpcMiddleware, cfg.GRPCMiddleware...)
 
 	grpcStreamMiddleware := []grpc.StreamServerInterceptor{
 		serverLog.StreamServerInterceptor,
 		otgrpc.OpenTracingStreamServerInterceptor(opentracing.GlobalTracer()),
-		middleware.StreamServerInstrumentInterceptor(metrics.RequestDuration),
+		middleware.StreamServerInstrumentInterceptor(metrics.Duration),
 	}
 	grpcStreamMiddleware = append(grpcStreamMiddleware, cfg.GRPCStreamMiddleware...)
 
@@ -360,8 +360,8 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		grpc.MaxSendMsgSize(cfg.GRPCServerMaxSendMsgSize),
 		grpc.MaxConcurrentStreams(uint32(cfg.GPRCServerMaxConcurrentStreams)),
 		grpc.StatsHandler(middleware.NewStatsHandler(
-			metrics.ReceivedMessageSize,
-			metrics.SentMessageSize,
+			metrics.RequestBodySize,
+			metrics.ResponseBodySize,
 			metrics.InflightRequests,
 		)),
 	}
@@ -408,9 +408,9 @@ func newServer(cfg Config, metrics *Metrics) (*Server, error) {
 		defaultLogMiddleware,
 		middleware.Instrument{
 			RouteMatcher:     router,
-			Duration:         metrics.RequestDuration,
-			RequestBodySize:  metrics.ReceivedMessageSize,
-			ResponseBodySize: metrics.SentMessageSize,
+			Duration:         metrics.Duration,
+			RequestBodySize:  metrics.RequestBodySize,
+			ResponseBodySize: metrics.ResponseBodySize,
 			InflightRequests: metrics.InflightRequests,
 		},
 	}


### PR DESCRIPTION
Make them the same names as used in metrics.Instrument, for consistency.

Sorry I missed this in the review of #289.
It was only merged a couple of months back, so hopefully not too painful for users.